### PR TITLE
refactor/auth token consumption

### DIFF
--- a/server/src/main/java/org/eni/koinoniadaily/modules/token/TokenRepository.java
+++ b/server/src/main/java/org/eni/koinoniadaily/modules/token/TokenRepository.java
@@ -12,8 +12,6 @@ import org.springframework.transaction.annotation.Transactional;
 @Repository
 public interface TokenRepository extends JpaRepository<Token, Long> {
 
-  Optional<Token> findByEmailAndType(String email, TokenType type);
-
   Optional<Token> findByEmailAndTypeAndValue(String email, TokenType type, String value);
 
   @Modifying(clearAutomatically = true)


### PR DESCRIPTION
### What was changed

- Move otp generate and save method to token service
- Remove token invalidation from generate and save method
- Add token invalidation to otp consumption 

### Why it was changed
- centralize token management service 
- clean up unexpected side effects in methods according to name
 
 
### How it was implemented
- move generate and save token method from auth service to token service
- remove token invalidation from generation point and move into consumption point

### Linked Issue
Closing #22