### PR TITLE
config/setup rate limiter

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -109,6 +109,16 @@
 			<artifactId>ses</artifactId>
 			<version>2.41.8</version>
 		</dependency>
+		<dependency>
+			<groupId>com.bucket4j</groupId>
+			<artifactId>bucket4j_jdk17-core</artifactId>
+			<version>8.16.0</version>
+		</dependency>
+		<dependency>
+			<groupId>com.github.ben-manes.caffeine</groupId>
+			<artifactId>caffeine</artifactId>
+			<version>3.1.8</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -117,7 +117,6 @@
 		<dependency>
 			<groupId>com.github.ben-manes.caffeine</groupId>
 			<artifactId>caffeine</artifactId>
-			<version>3.1.8</version>
 		</dependency>
 	</dependencies>
 

--- a/server/src/main/java/org/eni/koinoniadaily/config/AppProperties.java
+++ b/server/src/main/java/org/eni/koinoniadaily/config/AppProperties.java
@@ -16,6 +16,7 @@ public class AppProperties {
   private int version = 1;
 
   @NotBlank(message = "JWT secret not set in env")
+  @Size(min = 32, message = "JWT secret must be at least 32 characters")
   private String jwtSecret;
 
   @NotBlank(message = "Seeder user password not set in env")

--- a/server/src/main/java/org/eni/koinoniadaily/config/SecurityConfig.java
+++ b/server/src/main/java/org/eni/koinoniadaily/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package org.eni.koinoniadaily.config;
 
+import org.eni.koinoniadaily.config.ratelimit.RateLimitFilter;
 import org.eni.koinoniadaily.modules.auth.JpaUserDetailsService;
 
 import org.springframework.context.annotation.Bean;
@@ -24,6 +25,7 @@ import lombok.RequiredArgsConstructor;
 public class SecurityConfig {
 
   private final JpaUserDetailsService userDetailsService;
+  private final RateLimitFilter rateLimitFilter;
   private final JwtFilter jwtFilter;
   
   @Bean
@@ -35,6 +37,7 @@ public class SecurityConfig {
                                     .requestMatchers("/api/auth/**").permitAll()
                                     .anyRequest().authenticated())
             .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .addFilterBefore(rateLimitFilter, JwtFilter.class)
             .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
             .userDetailsService(userDetailsService)
             .build();

--- a/server/src/main/java/org/eni/koinoniadaily/config/SecurityConfig.java
+++ b/server/src/main/java/org/eni/koinoniadaily/config/SecurityConfig.java
@@ -37,8 +37,8 @@ public class SecurityConfig {
                                     .requestMatchers("/api/auth/**").permitAll()
                                     .anyRequest().authenticated())
             .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-            .addFilterBefore(rateLimitFilter, JwtFilter.class)
-            .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
+            .addFilterBefore(rateLimitFilter, UsernamePasswordAuthenticationFilter.class)
+            .addFilterAfter(jwtFilter, RateLimitFilter.class)
             .userDetailsService(userDetailsService)
             .build();
   }

--- a/server/src/main/java/org/eni/koinoniadaily/config/ratelimit/RateLimitBucketService.java
+++ b/server/src/main/java/org/eni/koinoniadaily/config/ratelimit/RateLimitBucketService.java
@@ -17,7 +17,6 @@ public class RateLimitBucketService {
 
   public boolean consume(String key, Supplier<Bucket> bucketSupplier) {
 
-    @SuppressWarnings("unused")
     Bucket bucket = cache.get(key, k -> bucketSupplier.get());
 
     return bucket.tryConsume(1);

--- a/server/src/main/java/org/eni/koinoniadaily/config/ratelimit/RateLimitBucketService.java
+++ b/server/src/main/java/org/eni/koinoniadaily/config/ratelimit/RateLimitBucketService.java
@@ -1,0 +1,25 @@
+package org.eni.koinoniadaily.config.ratelimit;
+
+import java.util.function.Supplier;
+
+import org.springframework.stereotype.Service;
+
+import com.github.benmanes.caffeine.cache.Cache;
+
+import io.github.bucket4j.Bucket;
+import lombok.AllArgsConstructor;
+
+@Service
+@AllArgsConstructor
+public class RateLimitBucketService {
+  
+  private final Cache<String, Bucket> cache;
+
+  public boolean consume(String key, Supplier<Bucket> bucketSupplier) {
+
+    @SuppressWarnings("unused")
+    Bucket bucket = cache.get(key, k -> bucketSupplier.get());
+
+    return bucket.tryConsume(1);
+  }
+}

--- a/server/src/main/java/org/eni/koinoniadaily/config/ratelimit/RateLimitCacheConfig.java
+++ b/server/src/main/java/org/eni/koinoniadaily/config/ratelimit/RateLimitCacheConfig.java
@@ -1,0 +1,23 @@
+package org.eni.koinoniadaily.config.ratelimit;
+
+import java.time.Duration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+
+import io.github.bucket4j.Bucket;
+
+@Configuration
+public class RateLimitCacheConfig {
+  
+  @Bean
+  Cache<String, Bucket> rateLimitCache() {
+    return Caffeine.newBuilder()
+            .expireAfterAccess(Duration.ofMinutes(10))
+            .maximumSize(100_000)
+            .build();
+  }
+}

--- a/server/src/main/java/org/eni/koinoniadaily/config/ratelimit/RateLimitFilter.java
+++ b/server/src/main/java/org/eni/koinoniadaily/config/ratelimit/RateLimitFilter.java
@@ -1,0 +1,86 @@
+package org.eni.koinoniadaily.config.ratelimit;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+
+import org.eni.koinoniadaily.utils.ErrorResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class RateLimitFilter extends OncePerRequestFilter {
+  
+  private final ObjectMapper objectMapper;
+  private final RateLimitBucketService bucketService;
+
+  @Override
+  protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+      throws ServletException, IOException {
+    
+    String clientIP = getClientIP(request);
+
+    String ipBucketKey = "ip:" + clientIP;
+
+    if(!bucketService.consume(ipBucketKey, RateLimitPolicy::ipBucket)) {
+      sendRateLimitExceededResponse(request, response);
+      return;
+    }
+
+    String sensitiveEndpointBucketKey = "sensitive:" + clientIP + ":" + request.getRequestURI();
+
+    if(isSensitiveEndpoint(request) && !bucketService.consume(sensitiveEndpointBucketKey, RateLimitPolicy::sensitiveEndpointBucket)) {
+      sendRateLimitExceededResponse(request, response);
+      return;
+    }
+    
+    filterChain.doFilter(request, response);
+  }
+
+  private String getClientIP(HttpServletRequest request) {
+
+    String header = request.getHeader("X-Forwarded-For");
+    if (header == null) {
+      return request.getRemoteAddr();
+    }
+    return header.split(",")[0].trim();
+  }
+
+  private boolean isSensitiveEndpoint(HttpServletRequest request) {
+
+    String uri = request.getRequestURI();
+
+    return uri.startsWith("/api/auth/login") ||
+           uri.startsWith("/api/auth/register") ||
+           uri.startsWith("/api/auth/verify-email") ||
+           uri.startsWith("/api/auth/request-otp") ||
+           uri.startsWith("/api/auth/forgot-password") ||
+           uri.startsWith("/api/auth/reset-password") ||
+           uri.startsWith("/api/auth/refresh-token");
+  }
+
+  private void sendRateLimitExceededResponse(HttpServletRequest request, HttpServletResponse response) throws IOException {
+
+    ErrorResponse error = ErrorResponse.builder()
+                            .success(false)
+                            .status(HttpStatus.TOO_MANY_REQUESTS.value())
+                            .error(HttpStatus.TOO_MANY_REQUESTS.getReasonPhrase())
+                            .message("Too many request. Please try again later.")
+                            .path(request.getRequestURI())
+                            .timestamp(LocalDateTime.now())
+                            .build();     
+    
+    response.setStatus(HttpStatus.TOO_MANY_REQUESTS.value());
+    response.setContentType("application/json");
+    objectMapper.writeValue(response.getWriter(), error);
+  }
+}

--- a/server/src/main/java/org/eni/koinoniadaily/config/ratelimit/RateLimitFilter.java
+++ b/server/src/main/java/org/eni/koinoniadaily/config/ratelimit/RateLimitFilter.java
@@ -27,7 +27,7 @@ public class RateLimitFilter extends OncePerRequestFilter {
   protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
       throws ServletException, IOException {
     
-    String clientIP = getClientIP(request);
+    String clientIP = request.getRemoteAddr();
 
     String ipBucketKey = "ip:" + clientIP;
 
@@ -44,15 +44,6 @@ public class RateLimitFilter extends OncePerRequestFilter {
     }
     
     filterChain.doFilter(request, response);
-  }
-
-  private String getClientIP(HttpServletRequest request) {
-
-    String header = request.getHeader("X-Forwarded-For");
-    if (header == null) {
-      return request.getRemoteAddr();
-    }
-    return header.split(",")[0].trim();
   }
 
   private boolean isSensitiveEndpoint(HttpServletRequest request) {

--- a/server/src/main/java/org/eni/koinoniadaily/config/ratelimit/RateLimitPolicy.java
+++ b/server/src/main/java/org/eni/koinoniadaily/config/ratelimit/RateLimitPolicy.java
@@ -4,9 +4,10 @@ import java.time.Duration;
 
 import io.github.bucket4j.Bandwidth;
 import io.github.bucket4j.Bucket;
+import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class RateLimitPolicy {
   
   public static Bucket ipBucket() {

--- a/server/src/main/java/org/eni/koinoniadaily/config/ratelimit/RateLimitPolicy.java
+++ b/server/src/main/java/org/eni/koinoniadaily/config/ratelimit/RateLimitPolicy.java
@@ -13,7 +13,7 @@ public final class RateLimitPolicy {
 
     Bandwidth bandwidth = Bandwidth.builder()
                             .capacity(100)
-                            .refillGreedy(1100, Duration.ofMinutes(1))
+                            .refillGreedy(100, Duration.ofMinutes(1))
                             .build();
 
     return Bucket.builder()

--- a/server/src/main/java/org/eni/koinoniadaily/config/ratelimit/RateLimitPolicy.java
+++ b/server/src/main/java/org/eni/koinoniadaily/config/ratelimit/RateLimitPolicy.java
@@ -1,0 +1,35 @@
+package org.eni.koinoniadaily.config.ratelimit;
+
+import java.time.Duration;
+
+import io.github.bucket4j.Bandwidth;
+import io.github.bucket4j.Bucket;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+public final class RateLimitPolicy {
+  
+  public static Bucket ipBucket() {
+
+    Bandwidth bandwidth = Bandwidth.builder()
+                            .capacity(100)
+                            .refillGreedy(1100, Duration.ofMinutes(1))
+                            .build();
+
+    return Bucket.builder()
+            .addLimit(bandwidth)
+            .build();
+  }
+
+  public static Bucket sensitiveEndpointBucket() {
+
+    Bandwidth bandwidth = Bandwidth.builder()
+                            .capacity(5)
+                            .refillGreedy(5, Duration.ofMinutes(1))
+                            .build();
+
+    return Bucket.builder()
+            .addLimit(bandwidth)
+            .build();
+  } 
+}

--- a/server/src/main/java/org/eni/koinoniadaily/modules/auth/AuthService.java
+++ b/server/src/main/java/org/eni/koinoniadaily/modules/auth/AuthService.java
@@ -86,7 +86,7 @@ public class AuthService {
   }
 
   @Transactional
-	public void verifyEmail(VerifyEmailDto request) {
+  public void verifyEmail(VerifyEmailDto request) {
 
 		User user = userRepository.findByEmail(request.getEmail())
                   .orElseThrow(() -> new NotFoundException("User not found"));
@@ -100,10 +100,10 @@ public class AuthService {
     user.setVerified(true);
 
     publisher.publishEvent(new UserRegisteredEvent(user.getEmail(), user.getFirstName()));
-	}
+  }
 
   @Transactional
-	public void requestOtp(RequestOtpDto request) {
+  public void requestOtp(RequestOtpDto request) {
     
 		User user = userRepository.findByEmail(request.getEmail())
                   .orElseThrow(() -> new NotFoundException("User not found"));
@@ -115,7 +115,7 @@ public class AuthService {
     String otp = tokenService.generateAndSaveOtp(user.getEmail(), TokenType.VERIFY_EMAIL);
 
     publisher.publishEvent(new EmailVerificationRequestedEvent(user.getEmail(), user.getFirstName(), otp));
-	}
+  }
 
   @Transactional
   public void forgotPassword(ForgotPasswordDto request) {

--- a/server/src/main/java/org/eni/koinoniadaily/modules/auth/dto/ChangePasswordDto.java
+++ b/server/src/main/java/org/eni/koinoniadaily/modules/auth/dto/ChangePasswordDto.java
@@ -10,10 +10,10 @@ import lombok.Setter;
 public class ChangePasswordDto {
   
   @NotBlank(message = "Current password is required")
-  @Size(min = 8, message = "Minimum password length of 8 required")
+  @Size(min = 8, max = 72, message = "Minimum password length of 8 required")
   private String currentPassword;
 
   @NotBlank(message = "New password is required")
-  @Size(min = 8, message = "Minimum password length of 8 required")
+  @Size(min = 8, max = 72, message = "Minimum password length of 8 required")
   private String newPassword;
 }

--- a/server/src/main/java/org/eni/koinoniadaily/modules/auth/dto/ResetPasswordDto.java
+++ b/server/src/main/java/org/eni/koinoniadaily/modules/auth/dto/ResetPasswordDto.java
@@ -15,7 +15,7 @@ public class ResetPasswordDto {
   private String email;
 
   @NotBlank(message = "Password is required")
-  @Size(min = 8, message = "Minimum password length of 8 required")
+  @Size(min = 8, max = 72, message = "Minimum password length of 8 required")
   private String password;
   
   @NotBlank(message = "OTP is required")

--- a/server/src/main/java/org/eni/koinoniadaily/modules/token/TokenService.java
+++ b/server/src/main/java/org/eni/koinoniadaily/modules/token/TokenService.java
@@ -18,11 +18,10 @@ import lombok.RequiredArgsConstructor;
 public class TokenService {
 
   private final TokenRepository tokenRepository;
-  private final TokenUtil tokenUtil;
   private final JwtService jwtService;
   private static final int OTP_EXPIRATION_MINUTES = 15;
-  private static final long ACCESS_TOKEN_EXPIRATION_MS = Duration.ofDays(7).toMillis();
-  private static final long REFRESH_TOKEN_EXPIRATION_MS = Duration.ofDays(31).toMillis();
+  private static final long ACCESS_TOKEN_EXPIRATION_MS = Duration.ofDays(1).toMillis();
+  private static final long REFRESH_TOKEN_EXPIRATION_MS = Duration.ofDays(14).toMillis();
 
   private void create(String email, String value, TokenType type, LocalDateTime expiresAt) {
 
@@ -40,7 +39,7 @@ public class TokenService {
   @Transactional
   public String generateAndSaveOtp(String email, TokenType type) {
 
-    String otp = tokenUtil.generateOtp();
+    String otp = TokenUtil.generateOtp();
 
     create(email, otp, type, LocalDateTime.now().plusMinutes(OTP_EXPIRATION_MINUTES));
     

--- a/server/src/main/java/org/eni/koinoniadaily/modules/token/TokenUtil.java
+++ b/server/src/main/java/org/eni/koinoniadaily/modules/token/TokenUtil.java
@@ -1,16 +1,12 @@
 package org.eni.koinoniadaily.modules.token;
 
-
-import org.springframework.stereotype.Component;
-
 import java.security.SecureRandom;
 
-@Component
-public class TokenUtil {
+public final class TokenUtil {
 
-  private final SecureRandom random = new SecureRandom();
+  private static final SecureRandom random = new SecureRandom();
 
-  public String generateOtp() {
+  public static String generateOtp() {
     
     StringBuilder sb = new StringBuilder();
 

--- a/server/src/main/java/org/eni/koinoniadaily/modules/token/TokenUtil.java
+++ b/server/src/main/java/org/eni/koinoniadaily/modules/token/TokenUtil.java
@@ -4,6 +4,10 @@ import java.security.SecureRandom;
 
 public final class TokenUtil {
 
+  private TokenUtil() {
+    
+  }
+
   private static final SecureRandom random = new SecureRandom();
 
   public static String generateOtp() {

--- a/server/src/main/java/org/eni/koinoniadaily/modules/user/User.java
+++ b/server/src/main/java/org/eni/koinoniadaily/modules/user/User.java
@@ -72,6 +72,5 @@ public class User extends BaseEntity {
     if (this.role == null) {
       this.role = UserRole.USER;
     }
-
   }
 }

--- a/server/src/main/resources/schema.sql
+++ b/server/src/main/resources/schema.sql
@@ -13,3 +13,5 @@ CREATE TABLE IF NOT EXISTS test_table (
 -- DROP TABLE IF EXISTS series CASCADE;
 
 -- ALTER TABLE series RENAME COLUMN title TO name;
+
+-- alter table if exists tokens RENAME column "'type'" TO type;


### PR DESCRIPTION
### What was changed

- setup rate limiting filter
- cleanup and small random improvements

### Why it was changed
- secure API request rate
- protect sensitive endpoints

### How it was implemented
- setup performant in-memory caching with caffeine
- setup separate token bucket for IP and Sensitive endpoints with bucket4j

### Linked Issue
closes #43 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added rate limiting to sensitive endpoints (login, registration, password reset, OTP requests) to prevent abuse.

* **Improvements**
  * Enhanced password validation with an 8–72 character length requirement for improved security.
  * Adjusted token expiration periods for better session management.
  * Strengthened JWT secret validation requirements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->