### PR TITLE
feat(s3-file): setup s3 file management

### DIFF
--- a/server/src/main/java/org/eni/koinoniadaily/config/S3Config.java
+++ b/server/src/main/java/org/eni/koinoniadaily/config/S3Config.java
@@ -1,0 +1,44 @@
+package org.eni.koinoniadaily.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import lombok.RequiredArgsConstructor;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+@Configuration
+@RequiredArgsConstructor
+public class S3Config {
+  
+  private final AppProperties props;
+
+  @Bean
+  S3Client s3Client() {
+    AwsBasicCredentials credentials = AwsBasicCredentials.create(
+        props.getAws().getAccessKey(), 
+        props.getAws().getSecretKey()
+    );
+    
+    return S3Client.builder()
+            .credentialsProvider(StaticCredentialsProvider.create(credentials))
+            .region(Region.of(props.getAws().getRegion()))
+            .build();
+  }
+
+  @Bean
+  S3Presigner s3Presigner() {
+    AwsBasicCredentials credentials = AwsBasicCredentials.create(
+        props.getAws().getAccessKey(), 
+        props.getAws().getSecretKey()
+    );
+    
+    return S3Presigner.builder()
+            .credentialsProvider(StaticCredentialsProvider.create(credentials))
+            .region(Region.of(props.getAws().getRegion()))
+            .build();
+  }
+}

--- a/server/src/main/java/org/eni/koinoniadaily/config/ratelimit/RateLimitBucketService.java
+++ b/server/src/main/java/org/eni/koinoniadaily/config/ratelimit/RateLimitBucketService.java
@@ -17,6 +17,7 @@ public class RateLimitBucketService {
 
   public boolean consume(String key, Supplier<Bucket> bucketSupplier) {
 
+    @SuppressWarnings("unused")
     Bucket bucket = cache.get(key, k -> bucketSupplier.get());
 
     return bucket.tryConsume(1);

--- a/server/src/main/java/org/eni/koinoniadaily/modules/file/FileController.java
+++ b/server/src/main/java/org/eni/koinoniadaily/modules/file/FileController.java
@@ -1,0 +1,47 @@
+package org.eni.koinoniadaily.modules.file;
+
+import org.eni.koinoniadaily.modules.file.dto.PresignedUploadUrlRequest;
+import org.eni.koinoniadaily.modules.file.dto.PresignedUploadUrlResponse;
+import org.eni.koinoniadaily.utils.SuccessResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/file")
+@Validated
+public class FileController {
+  
+  private final FileService fileService;
+
+  @PostMapping("/presign")
+  @PreAuthorize("hasAuthority('ADMIN')")
+  public ResponseEntity<SuccessResponse<PresignedUploadUrlResponse>> generateUploadPresignedUrl(
+    @RequestBody @Valid PresignedUploadUrlRequest request
+  ) {
+    PresignedUploadUrlResponse response = fileService.generatePresignedUploadUrl(request);
+
+    return ResponseEntity.ok(SuccessResponse.of(response, "Presigned upload URL generated successfully"));
+  }
+
+  @DeleteMapping
+  @PreAuthorize("hasAuthority('ADMIN')")
+  public ResponseEntity<SuccessResponse<Void>> deleteFile(
+    @RequestParam @NotBlank String objectKey
+  ) {
+    fileService.deleteObject(objectKey);
+
+    return ResponseEntity.ok(SuccessResponse.message("File deleted successfully"));
+  }
+}

--- a/server/src/main/java/org/eni/koinoniadaily/modules/file/FileService.java
+++ b/server/src/main/java/org/eni/koinoniadaily/modules/file/FileService.java
@@ -1,0 +1,74 @@
+package org.eni.koinoniadaily.modules.file;
+
+import java.net.URL;
+import java.time.Duration;
+import java.util.UUID;
+
+import org.eni.koinoniadaily.config.AppProperties;
+import org.eni.koinoniadaily.modules.file.dto.PresignedUploadUrlRequest;
+import org.eni.koinoniadaily.modules.file.dto.PresignedUploadUrlResponse;
+import org.springframework.stereotype.Service;
+
+import jakarta.validation.ValidationException;
+import lombok.RequiredArgsConstructor;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+@Service
+@RequiredArgsConstructor
+public class FileService {
+  
+  private final S3Client s3Client;
+  private final S3Presigner s3Presigner;
+  private final AppProperties props;
+
+  public PresignedUploadUrlResponse generatePresignedUploadUrl(PresignedUploadUrlRequest request) {
+
+    String objectKey = "thumbnails/" + UUID.randomUUID() + "." + request.getFileExtension();
+
+    PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                                          .bucket(props.getAws().getS3BucketName())
+                                          .key(objectKey)
+                                          .contentType(request.getContentType())
+                                          .acl(ObjectCannedACL.PUBLIC_READ)
+                                          .build();
+
+    PutObjectPresignRequest presignRequest = PutObjectPresignRequest.builder()
+                                              .signatureDuration(Duration.ofMinutes(10)) 
+                                              .putObjectRequest(putObjectRequest)
+                                              .build();
+
+    PresignedPutObjectRequest presignedRequest = s3Presigner.presignPutObject(presignRequest);
+    
+    URL presignedUrl = presignedRequest.url();
+
+    URL objectUrl = s3Client.utilities().getUrl(builder -> 
+                      builder.bucket(props.getAws().getS3BucketName())
+                        .key(objectKey));
+
+    return PresignedUploadUrlResponse.builder()
+            .presignedUrl(presignedUrl.toString())
+            .publicUrl(objectUrl.toString())
+            .key(objectKey)
+            .build();
+  }
+
+  public void deleteObject(String objectKey) {
+
+    if (!objectKey.startsWith("thumbnails/")) {
+      throw new ValidationException("Invalid object key");
+    }
+
+    DeleteObjectRequest request = DeleteObjectRequest.builder()
+                                    .bucket(props.getAws().getS3BucketName())
+                                    .key(objectKey)
+                                    .build();
+
+    s3Client.deleteObject(request);
+  }
+}

--- a/server/src/main/java/org/eni/koinoniadaily/modules/file/FileService.java
+++ b/server/src/main/java/org/eni/koinoniadaily/modules/file/FileService.java
@@ -62,7 +62,7 @@ public class FileService {
 
   public void deleteObject(String objectKey) {
 
-    if (!objectKey.startsWith("thumbnails/") || objectKey.contains("../")) {
+    if (objectKey == null || !objectKey.startsWith("thumbnails/") || objectKey.contains("../")) {
       throw new ValidationException("Invalid object key");
     }
 

--- a/server/src/main/java/org/eni/koinoniadaily/modules/file/FileService.java
+++ b/server/src/main/java/org/eni/koinoniadaily/modules/file/FileService.java
@@ -2,6 +2,7 @@ package org.eni.koinoniadaily.modules.file;
 
 import java.net.URL;
 import java.time.Duration;
+import java.util.Locale;
 import java.util.UUID;
 
 import org.eni.koinoniadaily.config.AppProperties;
@@ -74,18 +75,13 @@ public class FileService {
   }
 
   private String getContentType(String fileExtension) {
-    switch (fileExtension.toLowerCase()) {
-      case "jpg":
-      case "jpeg":
-        return "image/jpeg";
-      case "png":
-        return "image/png";
-      case "gif":
-        return "image/gif";
-      case "webp":
-        return "image/webp";
-      default:
-        throw new ValidationException("Unsupported file extension");
-    }
+    
+    return switch (fileExtension.toLowerCase(Locale.ROOT)) {
+      case "jpg", "jpeg" -> "image/jpeg";
+      case "png" -> "image/png";
+      case "gif" -> "image/gif";
+      case "webp" -> "image/webp";
+      default -> "application/octet-stream";
+    };
   }
 }

--- a/server/src/main/java/org/eni/koinoniadaily/modules/file/dto/PresignedUploadUrlRequest.java
+++ b/server/src/main/java/org/eni/koinoniadaily/modules/file/dto/PresignedUploadUrlRequest.java
@@ -11,7 +11,7 @@ public class PresignedUploadUrlRequest {
   
   @NotBlank(message = "File extension is required")
   @Pattern(
-      regexp = "^(jpg|jpeg|png|gif|webp)$", 
+      regexp = "(?i)^(jpg|jpeg|png|gif|webp)$", 
       message = "Invalid file extension. Allowed extensions are: jpg, jpeg, png, gif, webp"
   )
   private String fileExtension;

--- a/server/src/main/java/org/eni/koinoniadaily/modules/file/dto/PresignedUploadUrlRequest.java
+++ b/server/src/main/java/org/eni/koinoniadaily/modules/file/dto/PresignedUploadUrlRequest.java
@@ -15,11 +15,4 @@ public class PresignedUploadUrlRequest {
       message = "Invalid file extension. Allowed extensions are: jpg, jpeg, png, gif, webp"
   )
   private String fileExtension;
-  
-  @NotBlank(message = "Content type is required")
-  @Pattern(
-      regexp = "^(image/jpeg|image/png|image/gif|image/webp)$", 
-      message = "Invalid content type. Allowed types are: image/jpeg, image/png, image/gif, image/webp"
-  )
-  private String contentType;
 }

--- a/server/src/main/java/org/eni/koinoniadaily/modules/file/dto/PresignedUploadUrlRequest.java
+++ b/server/src/main/java/org/eni/koinoniadaily/modules/file/dto/PresignedUploadUrlRequest.java
@@ -1,0 +1,25 @@
+package org.eni.koinoniadaily.modules.file.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class PresignedUploadUrlRequest {
+  
+  @NotBlank(message = "File extension is required")
+  @Pattern(
+      regexp = "^(jpg|jpeg|png|gif|webp)$", 
+      message = "Invalid file extension. Allowed extensions are: jpg, jpeg, png, gif, webp"
+  )
+  private String fileExtension;
+  
+  @NotBlank(message = "Content type is required")
+  @Pattern(
+      regexp = "^(image/jpeg|image/png|image/gif|image/webp)$", 
+      message = "Invalid content type. Allowed types are: image/jpeg, image/png, image/gif, image/webp"
+  )
+  private String contentType;
+}

--- a/server/src/main/java/org/eni/koinoniadaily/modules/file/dto/PresignedUploadUrlResponse.java
+++ b/server/src/main/java/org/eni/koinoniadaily/modules/file/dto/PresignedUploadUrlResponse.java
@@ -1,0 +1,15 @@
+package org.eni.koinoniadaily.modules.file.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PresignedUploadUrlResponse {
+  
+  private String presignedUrl;
+
+  private String publicUrl;
+
+  private String key;
+}

--- a/server/src/main/java/org/eni/koinoniadaily/modules/file/dto/PresignedUploadUrlResponse.java
+++ b/server/src/main/java/org/eni/koinoniadaily/modules/file/dto/PresignedUploadUrlResponse.java
@@ -1,5 +1,8 @@
 package org.eni.koinoniadaily.modules.file.dto;
 
+import java.util.List;
+import java.util.Map;
+
 import lombok.Builder;
 import lombok.Getter;
 
@@ -12,4 +15,6 @@ public class PresignedUploadUrlResponse {
   private String publicUrl;
 
   private String key;
+
+  private Map<String, List<String>> requiredHeaders;
 }


### PR DESCRIPTION
### What was changed

- add API endpoint for generating presigned upload ur
- add endpoint for deleting object by key

### Why it was changed
- consistent response format
- s3 file management

### How it was implemented
- generate presigned upload url with objectKey, public url response
- delete object with key

### Linked Issue
Closing #51 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin-only endpoints to request presigned upload URLs (JPG/PNG/GIF/WebP) and to delete stored files.
  * Server now generates presigned upload links plus a public object URL and required headers for direct uploads; presigned links expire after ~10 minutes.
* **Security/Validation**
  * File deletion validates object keys to prevent path-traversal.
* **Chore**
  * Added AWS S3 client/presigner configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->