### PR TITLE
ci(dependabot): change schedule to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,6 @@ updates:
     directory: "/server"
     schedule:
       interval: "monthly"
-      day: "monday"
       time: "09:00"
 
     target-branch: "develop"
@@ -46,7 +45,6 @@ updates:
     directory: "/mobile"
     schedule:
       interval: "monthly"
-      day: "monday"
       time: "10:00"
 
     target-branch: "develop"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "maven"
     directory: "/server"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       day: "monday"
       time: "09:00"
 
@@ -45,7 +45,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/mobile"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       day: "monday"
       time: "10:00"
 

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -209,12 +209,12 @@ jobs:
         load: true
         tags: ${{ secrets.DOCKERHUB_USERNAME }}/koinonia-daily-server:${{ github.sha }}
       
-    - name: Scan Docker Image with Trivy
+    - name: Scan Docker Image with Trivy (Sarif)
       uses: aquasecurity/trivy-action@0.20.0
       with:
         image-ref: ${{ secrets.DOCKERHUB_USERNAME }}/koinonia-daily-server:${{ github.sha }}
         severity: 'CRITICAL,HIGH'
-        exit-code: '1'
+        exit-code: '0'
         format: sarif
         output: trivy-image-results.sarif
 
@@ -224,6 +224,14 @@ jobs:
       with:
         sarif_file: trivy-image-results.sarif
         category: "Trivy Docker Image Scan"
+
+    - name: Scan Docker Image with Trivy (Table)
+      uses: aquasecurity/trivy-action@0.20.0
+      with:
+        image-ref: ${{ secrets.DOCKERHUB_USERNAME }}/koinonia-daily-server:${{ github.sha }}
+        severity: 'CRITICAL,HIGH'
+        exit-code: '1'
+        format: table
         
     - name: Push Docker Image
       if: success()

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -14,7 +14,7 @@ COPY . .
 RUN mvn clean package -DskipTests
 
 # Development stage
-FROM build as development
+FROM build AS development
 
 ENV SPRING_PROFILES_ACTIVE=dev
 


### PR DESCRIPTION
### What was changed

- dependabot schedule frequency 

- CI docker truvy scan

### Why it was changed
- reduce PR noise
- persist trivy file for failed check

### How it was implemented
- updated schedule from weekly to monthly
- Added table display for trivy result and removed fail for trivy sarif scan

### Linked Issue
Closing #95

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Changed automated dependency update schedules from weekly to monthly.
  * Improved CI security scans to produce both machine-readable and human-readable reports; non-critical findings in machine-readable reports no longer fail the build.
  * Performed minor build configuration syntax normalization with no functional impact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->