### PR TITLE
fix: change localdatetime to instant for utc

### DIFF
--- a/server/src/main/java/org/eni/koinoniadaily/config/AppSeeder.java
+++ b/server/src/main/java/org/eni/koinoniadaily/config/AppSeeder.java
@@ -1,6 +1,7 @@
 package org.eni.koinoniadaily.config;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 
 import org.eni.koinoniadaily.modules.teaching.Teaching;
@@ -72,7 +73,7 @@ public class AppSeeder implements CommandLineRunner {
             .tags("faith,supernatural,kingdom")
             .type(TeachingType.SUNDAY_SERVICE)
             .summary("This series we are going to look into the dynamics of faith in establishing the ordinances of the kingdom here on earth.")
-            .taughtAt(LocalDateTime.now().minusDays(14))
+            .taughtAt(Instant.now().minus(14, ChronoUnit.DAYS))
             .build(),
           Teaching.builder()
             .title("Commanding the Supernatural Part 2")
@@ -84,7 +85,7 @@ public class AppSeeder implements CommandLineRunner {
             .tags("faith,supernatural,kingdom")
             .type(TeachingType.SUNDAY_SERVICE)
             .summary("In this message we continue to explore the dynamics of faith in establishing the ordinances of the kingdom here on earth.")
-            .taughtAt(LocalDateTime.now().minusDays(7))
+            .taughtAt(Instant.now().minus(7, ChronoUnit.DAYS))
             .build()
       );
       teachingRepository.saveAll(teachings);

--- a/server/src/main/java/org/eni/koinoniadaily/config/JwtFilter.java
+++ b/server/src/main/java/org/eni/koinoniadaily/config/JwtFilter.java
@@ -1,7 +1,7 @@
 package org.eni.koinoniadaily.config;
 
 import java.io.IOException;
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 import org.eni.koinoniadaily.exceptions.UnauthorizedException;
 import org.eni.koinoniadaily.modules.auth.JwtService;
@@ -77,7 +77,7 @@ public class JwtFilter extends OncePerRequestFilter {
                                       .error(HttpStatus.UNAUTHORIZED.getReasonPhrase())
                                       .message(ex.getMessage())
                                       .path(request.getRequestURI())
-                                      .timestamp(LocalDateTime.now())
+                                      .timestamp(Instant.now())
                                       .build();
 
       response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);

--- a/server/src/main/java/org/eni/koinoniadaily/config/ratelimit/RateLimitFilter.java
+++ b/server/src/main/java/org/eni/koinoniadaily/config/ratelimit/RateLimitFilter.java
@@ -1,7 +1,7 @@
 package org.eni.koinoniadaily.config.ratelimit;
 
 import java.io.IOException;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.Set;
 
 import org.eni.koinoniadaily.utils.ErrorResponse;
@@ -71,7 +71,7 @@ public class RateLimitFilter extends OncePerRequestFilter {
                             .error(HttpStatus.TOO_MANY_REQUESTS.getReasonPhrase())
                             .message("Too many requests. Please try again later.")
                             .path(request.getRequestURI())
-                            .timestamp(LocalDateTime.now())
+                            .timestamp(Instant.now())
                             .build();     
     
     response.setStatus(HttpStatus.TOO_MANY_REQUESTS.value());

--- a/server/src/main/java/org/eni/koinoniadaily/entity/BaseEntity.java
+++ b/server/src/main/java/org/eni/koinoniadaily/entity/BaseEntity.java
@@ -1,6 +1,6 @@
 package org.eni.koinoniadaily.entity;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
@@ -28,9 +28,9 @@ public abstract class BaseEntity {
 
   @CreationTimestamp
   @Column(nullable = false, updatable = false)
-  private LocalDateTime createdAt;
+  private Instant createdAt;
 
   @UpdateTimestamp
   @Column(nullable = false)
-  private LocalDateTime updatedAt;  
+  private Instant updatedAt;
 }

--- a/server/src/main/java/org/eni/koinoniadaily/exceptions/GlobalExceptionHandler.java
+++ b/server/src/main/java/org/eni/koinoniadaily/exceptions/GlobalExceptionHandler.java
@@ -14,7 +14,7 @@ import org.springframework.web.context.request.WebRequest;
 
 import jakarta.persistence.OptimisticLockException;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.stream.Collectors;
 
 @RestControllerAdvice
@@ -29,7 +29,7 @@ public class GlobalExceptionHandler {
                             .error(status.getReasonPhrase())
                             .message(message)
                             .path(((ServletWebRequest) request).getRequest().getRequestURI())
-                            .timestamp(LocalDateTime.now())
+                            .timestamp(Instant.now())
                             .build();
                         
     return new ResponseEntity<>(error, status);

--- a/server/src/main/java/org/eni/koinoniadaily/modules/account/dto/AccountProfileResponse.java
+++ b/server/src/main/java/org/eni/koinoniadaily/modules/account/dto/AccountProfileResponse.java
@@ -1,6 +1,6 @@
 package org.eni.koinoniadaily.modules.account.dto;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 import org.eni.koinoniadaily.modules.user.UserRole;
 
@@ -23,7 +23,7 @@ public class AccountProfileResponse {
 
   private UserRole role;
 
-  private LocalDateTime createdAt;
+  private Instant createdAt;
 
-  private LocalDateTime updatedAt;
+  private Instant updatedAt;
 }

--- a/server/src/main/java/org/eni/koinoniadaily/modules/auth/UserPrincipal.java
+++ b/server/src/main/java/org/eni/koinoniadaily/modules/auth/UserPrincipal.java
@@ -1,6 +1,6 @@
 package org.eni.koinoniadaily.modules.auth;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.Collection;
 import java.util.Collections;
 
@@ -26,8 +26,8 @@ public class UserPrincipal implements UserDetails {
   private final String photoUrl;
   private final UserRole role;
   private final boolean isVerified;
-  private final LocalDateTime createdAt;
-  private final LocalDateTime updatedAt;
+  private final Instant createdAt;
+  private final Instant updatedAt;
 
   private final String password;
   private final String username;

--- a/server/src/main/java/org/eni/koinoniadaily/modules/bookmark/dto/BookmarkResponse.java
+++ b/server/src/main/java/org/eni/koinoniadaily/modules/bookmark/dto/BookmarkResponse.java
@@ -1,6 +1,6 @@
 package org.eni.koinoniadaily.modules.bookmark.dto;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -19,11 +19,11 @@ public class BookmarkResponse {
 
   private String teachingThumbnailUrl;
 
-  private LocalDateTime teachingTaughtAt;
+  private Instant teachingTaughtAt;
 
   private String note;
 
-  private LocalDateTime createdAt;
+  private Instant createdAt;
 
-  private LocalDateTime updatedAt;
+  private Instant updatedAt;
 }

--- a/server/src/main/java/org/eni/koinoniadaily/modules/bookmarkcategory/dto/BookmarkCategoryResponse.java
+++ b/server/src/main/java/org/eni/koinoniadaily/modules/bookmarkcategory/dto/BookmarkCategoryResponse.java
@@ -1,6 +1,6 @@
 package org.eni.koinoniadaily.modules.bookmarkcategory.dto;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -19,7 +19,7 @@ public class BookmarkCategoryResponse {
 
   private Integer totalBookmarks;
 
-  private LocalDateTime createdAt;
+  private Instant createdAt;
 
-  private LocalDateTime updatedAt;
+  private Instant updatedAt;
 }

--- a/server/src/main/java/org/eni/koinoniadaily/modules/collection/dto/CollectionPageResponse.java
+++ b/server/src/main/java/org/eni/koinoniadaily/modules/collection/dto/CollectionPageResponse.java
@@ -1,6 +1,6 @@
 package org.eni.koinoniadaily.modules.collection.dto;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -21,9 +21,9 @@ public class CollectionPageResponse {
 
   private String thumbnailUrl;
   
-  private LocalDateTime createdAt;
+  private Instant createdAt;
   
-  private LocalDateTime updatedAt;
+  private Instant updatedAt;
 
   private Integer totalTeachings;
 }

--- a/server/src/main/java/org/eni/koinoniadaily/modules/collection/dto/CollectionResponse.java
+++ b/server/src/main/java/org/eni/koinoniadaily/modules/collection/dto/CollectionResponse.java
@@ -1,6 +1,6 @@
 package org.eni.koinoniadaily.modules.collection.dto;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 
 import org.eni.koinoniadaily.modules.teaching.projection.TeachingWithoutMessageProjection;
@@ -20,9 +20,9 @@ public class CollectionResponse {
 
   private String thumbnailUrl;
 
-  private LocalDateTime createdAt;
+  private Instant createdAt;
 
-  private LocalDateTime updatedAt;
+  private Instant updatedAt;
 
   private List<TeachingWithoutMessageProjection> teachings;
 }

--- a/server/src/main/java/org/eni/koinoniadaily/modules/collection/projection/CollectionWithTeachingsProjection.java
+++ b/server/src/main/java/org/eni/koinoniadaily/modules/collection/projection/CollectionWithTeachingsProjection.java
@@ -1,6 +1,6 @@
 package org.eni.koinoniadaily.modules.collection.projection;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 
 import org.eni.koinoniadaily.modules.teaching.projection.TeachingWithoutMessageProjection;
@@ -15,9 +15,9 @@ public interface CollectionWithTeachingsProjection {
 
   String getThumbnailUrl();
 
-  LocalDateTime getCreatedAt();
+  Instant getCreatedAt();
 
-  LocalDateTime getUpdatedAt();
+  Instant getUpdatedAt();
 
   List<TeachingWithoutMessageProjection> getTeachings();
 }

--- a/server/src/main/java/org/eni/koinoniadaily/modules/history/HistoryService.java
+++ b/server/src/main/java/org/eni/koinoniadaily/modules/history/HistoryService.java
@@ -1,6 +1,6 @@
 package org.eni.koinoniadaily.modules.history;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.Optional;
 
 import org.eni.koinoniadaily.exceptions.NotFoundException;
@@ -53,7 +53,7 @@ public class HistoryService {
 
     if (existingHistory.isPresent()) {
       
-      existingHistory.get().setUpdatedAt(LocalDateTime.now());
+      existingHistory.get().setUpdatedAt(Instant.now());
     } else {
       User user = userRepository.getReferenceById(userId);
       

--- a/server/src/main/java/org/eni/koinoniadaily/modules/history/dto/HistoryResponse.java
+++ b/server/src/main/java/org/eni/koinoniadaily/modules/history/dto/HistoryResponse.java
@@ -1,6 +1,6 @@
 package org.eni.koinoniadaily.modules.history.dto;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -19,11 +19,11 @@ public class HistoryResponse {
 
   private String teachingThumbnailUrl;
 
-  private LocalDateTime teachingTaughtAt;
+  private Instant teachingTaughtAt;
 
   private boolean isMarkedRead;
 
-  private LocalDateTime createdAt;
+  private Instant createdAt;
 
-  private LocalDateTime updatedAt;
+  private Instant updatedAt;
 }

--- a/server/src/main/java/org/eni/koinoniadaily/modules/series/dto/SeriesPageResponse.java
+++ b/server/src/main/java/org/eni/koinoniadaily/modules/series/dto/SeriesPageResponse.java
@@ -1,6 +1,6 @@
 package org.eni.koinoniadaily.modules.series.dto;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -19,9 +19,9 @@ public class SeriesPageResponse {
 
   private String thumbnailUrl;
 
-  private LocalDateTime createdAt;
+  private Instant createdAt;
 
-  private LocalDateTime updatedAt;
+  private Instant updatedAt;
 
   private Integer totalTeachings;
 }

--- a/server/src/main/java/org/eni/koinoniadaily/modules/series/dto/SeriesResponse.java
+++ b/server/src/main/java/org/eni/koinoniadaily/modules/series/dto/SeriesResponse.java
@@ -1,6 +1,6 @@
 package org.eni.koinoniadaily.modules.series.dto;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 
 import org.eni.koinoniadaily.modules.teaching.projection.TeachingWithoutMessageProjection;
@@ -20,9 +20,9 @@ public class SeriesResponse {
 
   private String thumbnailUrl;
 
-  private LocalDateTime createdAt;
+  private Instant createdAt;
 
-  private LocalDateTime updatedAt;
+  private Instant updatedAt;
 
   private List<TeachingWithoutMessageProjection> teachings;
 }

--- a/server/src/main/java/org/eni/koinoniadaily/modules/teaching/Teaching.java
+++ b/server/src/main/java/org/eni/koinoniadaily/modules/teaching/Teaching.java
@@ -1,6 +1,6 @@
 package org.eni.koinoniadaily.modules.teaching;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -77,7 +77,7 @@ public class Teaching extends BaseEntity {
   private Integer seriesPart;
 
   @Column(nullable = false)
-  private LocalDateTime taughtAt;
+  private Instant taughtAt;
 
   @ManyToMany(mappedBy = "teachings")
   @Builder.Default

--- a/server/src/main/java/org/eni/koinoniadaily/modules/teaching/dto/TeachingPageResponse.java
+++ b/server/src/main/java/org/eni/koinoniadaily/modules/teaching/dto/TeachingPageResponse.java
@@ -1,6 +1,6 @@
 package org.eni.koinoniadaily.modules.teaching.dto;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 import org.eni.koinoniadaily.modules.teaching.TeachingType;
 
@@ -31,9 +31,9 @@ public class TeachingPageResponse {
 
   private Integer seriesPart;
 
-  private LocalDateTime taughtAt;
+  private Instant taughtAt;
   
-  private LocalDateTime createdAt;
+  private Instant createdAt;
   
-  private LocalDateTime updatedAt;
+  private Instant updatedAt;
 }

--- a/server/src/main/java/org/eni/koinoniadaily/modules/teaching/dto/TeachingRequest.java
+++ b/server/src/main/java/org/eni/koinoniadaily/modules/teaching/dto/TeachingRequest.java
@@ -1,6 +1,6 @@
 package org.eni.koinoniadaily.modules.teaching.dto;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 import org.eni.koinoniadaily.modules.teaching.TeachingType;
 import org.hibernate.validator.constraints.URL;
@@ -48,5 +48,5 @@ public class TeachingRequest {
   private Integer seriesPart;
   
   @NotNull(message = "Record datetime is required")
-  private LocalDateTime taughtAt;
+  private Instant taughtAt;
 }

--- a/server/src/main/java/org/eni/koinoniadaily/modules/teaching/dto/TeachingResponse.java
+++ b/server/src/main/java/org/eni/koinoniadaily/modules/teaching/dto/TeachingResponse.java
@@ -1,6 +1,6 @@
 package org.eni.koinoniadaily.modules.teaching.dto;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 import org.eni.koinoniadaily.modules.series.dto.SeriesSummary;
 import org.eni.koinoniadaily.modules.teaching.TeachingType;
@@ -36,9 +36,9 @@ public class TeachingResponse {
 
   private Integer seriesPart;
 
-  private LocalDateTime taughtAt;
+  private Instant taughtAt;
   
-  private LocalDateTime createdAt;
+  private Instant createdAt;
   
-  private LocalDateTime updatedAt;
+  private Instant updatedAt;
 }

--- a/server/src/main/java/org/eni/koinoniadaily/modules/teaching/projection/TeachingWithoutMessageProjection.java
+++ b/server/src/main/java/org/eni/koinoniadaily/modules/teaching/projection/TeachingWithoutMessageProjection.java
@@ -1,6 +1,6 @@
 package org.eni.koinoniadaily.modules.teaching.projection;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 import org.eni.koinoniadaily.modules.teaching.TeachingType;
 
@@ -26,9 +26,9 @@ public interface TeachingWithoutMessageProjection {
 
   Integer getSeriesPart();
 
-  LocalDateTime getTaughtAt();
+  Instant getTaughtAt();
   
-  LocalDateTime getCreatedAt();
+  Instant getCreatedAt();
   
-  LocalDateTime getUpdatedAt();
+  Instant getUpdatedAt();
 }

--- a/server/src/main/java/org/eni/koinoniadaily/modules/token/Token.java
+++ b/server/src/main/java/org/eni/koinoniadaily/modules/token/Token.java
@@ -1,6 +1,6 @@
 package org.eni.koinoniadaily.modules.token;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 import org.eni.koinoniadaily.entity.BaseEntity;
 
@@ -39,12 +39,12 @@ public class Token extends BaseEntity {
   private boolean isUsed = false;
 
   @Column(nullable = false)
-  private LocalDateTime expiresAt;
+  private Instant expiresAt;
 
   @Version
   private Long version;
 
   public boolean isExpired() {
-    return LocalDateTime.now().isAfter(expiresAt);
+    return Instant.now().isAfter(expiresAt);
   }
 }

--- a/server/src/main/java/org/eni/koinoniadaily/modules/token/TokenService.java
+++ b/server/src/main/java/org/eni/koinoniadaily/modules/token/TokenService.java
@@ -1,7 +1,8 @@
 package org.eni.koinoniadaily.modules.token;
 
 import java.time.Duration;
-import java.time.LocalDateTime;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.UUID;
 
 import org.eni.koinoniadaily.modules.auth.JwtService;
@@ -23,7 +24,7 @@ public class TokenService {
   private static final long ACCESS_TOKEN_EXPIRATION_MS = Duration.ofDays(1).toMillis();
   private static final long REFRESH_TOKEN_EXPIRATION_MS = Duration.ofDays(14).toMillis();
 
-  private void create(String email, String value, TokenType type, LocalDateTime expiresAt) {
+  private void create(String email, String value, TokenType type, Instant expiresAt) {
 
     Token token = Token.builder()
                     .email(email)
@@ -41,7 +42,7 @@ public class TokenService {
 
     String otp = TokenUtil.generateOtp();
 
-    create(email, otp, type, LocalDateTime.now().plusMinutes(OTP_EXPIRATION_MINUTES));
+    create(email, otp, type, Instant.now().plus(OTP_EXPIRATION_MINUTES, ChronoUnit.MINUTES));
     
     return otp;
   }
@@ -90,7 +91,7 @@ public class TokenService {
     String accessToken = jwtService.generateToken(email, ACCESS_TOKEN_EXPIRATION_MS, TokenType.ACCESS_TOKEN, null);
     String refreshToken = jwtService.generateToken(email, REFRESH_TOKEN_EXPIRATION_MS, TokenType.REFRESH_TOKEN, jti);
 
-    create(email, jti, TokenType.REFRESH_TOKEN, LocalDateTime.now().plus(Duration.ofMillis(REFRESH_TOKEN_EXPIRATION_MS)));
+    create(email, jti, TokenType.REFRESH_TOKEN, Instant.now().plus(Duration.ofMillis(REFRESH_TOKEN_EXPIRATION_MS)));
 
     return new TokenPair(accessToken, refreshToken);
   }

--- a/server/src/main/java/org/eni/koinoniadaily/modules/transcript/dto/TranscriptPageResponse.java
+++ b/server/src/main/java/org/eni/koinoniadaily/modules/transcript/dto/TranscriptPageResponse.java
@@ -1,6 +1,6 @@
 package org.eni.koinoniadaily.modules.transcript.dto;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 import lombok.Builder;
 import lombok.Getter;
@@ -13,7 +13,7 @@ public class TranscriptPageResponse {
 
   private String title;
   
-  private LocalDateTime createdAt;
+  private Instant createdAt;
 
-  private LocalDateTime updatedAt;
+  private Instant updatedAt;
 }

--- a/server/src/main/java/org/eni/koinoniadaily/modules/transcript/dto/TranscriptResponse.java
+++ b/server/src/main/java/org/eni/koinoniadaily/modules/transcript/dto/TranscriptResponse.java
@@ -1,6 +1,6 @@
 package org.eni.koinoniadaily.modules.transcript.dto;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 import lombok.Builder;
 import lombok.Getter;
@@ -15,7 +15,7 @@ public class TranscriptResponse {
   
   private String message;
   
-  private LocalDateTime createdAt;
+  private Instant createdAt;
 
-  private LocalDateTime updatedAt;
+  private Instant updatedAt;
 }

--- a/server/src/main/java/org/eni/koinoniadaily/modules/transcript/projection/TranscriptWithoutMessageProjection.java
+++ b/server/src/main/java/org/eni/koinoniadaily/modules/transcript/projection/TranscriptWithoutMessageProjection.java
@@ -1,6 +1,6 @@
 package org.eni.koinoniadaily.modules.transcript.projection;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 public interface TranscriptWithoutMessageProjection {
 
@@ -8,7 +8,7 @@ public interface TranscriptWithoutMessageProjection {
 
   String getTitle();
   
-  LocalDateTime getCreatedAt();
+  Instant getCreatedAt();
   
-  LocalDateTime getUpdatedAt();  
+  Instant getUpdatedAt();  
 }

--- a/server/src/main/java/org/eni/koinoniadaily/utils/ErrorResponse.java
+++ b/server/src/main/java/org/eni/koinoniadaily/utils/ErrorResponse.java
@@ -1,6 +1,6 @@
 package org.eni.koinoniadaily.utils;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 import lombok.Getter;
 import lombok.experimental.SuperBuilder;
@@ -15,5 +15,5 @@ public class ErrorResponse extends ApiResponse {
   
   private final String path;
   
-  private final LocalDateTime timestamp;
+  private final Instant timestamp;
 }


### PR DESCRIPTION
### What was changed
-  change LocalDateTime instances to Instant 

### Why it was changed
-fix for UTC consistency on distributed Timestamps and locations.
- align with db Timestamptz usage

### How it was implemented
- basic update
- use chronounit where needed

### Linked Issue
Closing #109 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized timestamp representation throughout the application to use UTC-based instants, ensuring consistent temporal data handling across all API responses and internal operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->