### PR TITLE
fix/setup-v1-api-versioning

### DIFF
--- a/server/src/main/java/org/eni/koinoniadaily/config/JwtFilter.java
+++ b/server/src/main/java/org/eni/koinoniadaily/config/JwtFilter.java
@@ -77,6 +77,7 @@ public class JwtFilter extends OncePerRequestFilter {
                                       .error(HttpStatus.UNAUTHORIZED.getReasonPhrase())
                                       .message(ex.getMessage())
                                       .path(request.getRequestURI())
+                                      .errorCode(ex.getCause().getClass().getSimpleName())
                                       .timestamp(Instant.now())
                                       .build();
 

--- a/server/src/main/java/org/eni/koinoniadaily/config/JwtFilter.java
+++ b/server/src/main/java/org/eni/koinoniadaily/config/JwtFilter.java
@@ -77,7 +77,7 @@ public class JwtFilter extends OncePerRequestFilter {
                                       .error(HttpStatus.UNAUTHORIZED.getReasonPhrase())
                                       .message(ex.getMessage())
                                       .path(request.getRequestURI())
-                                      .errorCode(ex.getCause().getClass().getSimpleName())
+                                      .errorCode(ex.getCause() != null ? ex.getCause().getClass().getSimpleName() : "UNAUTHORIZED")
                                       .timestamp(Instant.now())
                                       .build();
 

--- a/server/src/main/java/org/eni/koinoniadaily/config/SecurityConfig.java
+++ b/server/src/main/java/org/eni/koinoniadaily/config/SecurityConfig.java
@@ -33,8 +33,8 @@ public class SecurityConfig {
     return http
             .csrf(customizer -> customizer.disable())
             .authorizeHttpRequests(request -> request
-                                    .requestMatchers("/api/auth/profile", "/api/auth/change-password").authenticated()
-                                    .requestMatchers("/api/auth/**").permitAll()
+                                    .requestMatchers("/api/v1/auth/profile", "/api/v1/auth/change-password").authenticated()
+                                    .requestMatchers("/api/v1/auth/**").permitAll()
                                     .anyRequest().authenticated())
             .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .addFilterBefore(rateLimitFilter, UsernamePasswordAuthenticationFilter.class)

--- a/server/src/main/java/org/eni/koinoniadaily/config/ratelimit/RateLimitFilter.java
+++ b/server/src/main/java/org/eni/koinoniadaily/config/ratelimit/RateLimitFilter.java
@@ -24,13 +24,13 @@ public class RateLimitFilter extends OncePerRequestFilter {
   private final ObjectMapper objectMapper;
   private final RateLimitBucketService bucketService;
   private static final Set<String> SENSITIVE_ENDPOINTS = Set.of(
-    "/api/auth/login",
-    "/api/auth/register",
-    "/api/auth/verify-email",
-    "/api/auth/request-otp",
-    "/api/auth/forgot-password",
-    "/api/auth/reset-password",
-    "/api/auth/refresh-token"
+    "/api/v1/auth/login",
+    "/api/v1/auth/register",
+    "/api/v1/auth/verify-email",
+    "/api/v1/auth/request-otp",
+    "/api/v1/auth/forgot-password",
+    "/api/v1/auth/reset-password",
+    "/api/v1/auth/refresh-token"
   );
 
   @Override

--- a/server/src/main/java/org/eni/koinoniadaily/config/ratelimit/RateLimitFilter.java
+++ b/server/src/main/java/org/eni/koinoniadaily/config/ratelimit/RateLimitFilter.java
@@ -71,6 +71,7 @@ public class RateLimitFilter extends OncePerRequestFilter {
                             .error(HttpStatus.TOO_MANY_REQUESTS.getReasonPhrase())
                             .message("Too many requests. Please try again later.")
                             .path(request.getRequestURI())
+                            .errorCode("RATE_LIMIT_EXCEEDED")
                             .timestamp(Instant.now())
                             .build();     
     

--- a/server/src/main/java/org/eni/koinoniadaily/exceptions/GlobalExceptionHandler.java
+++ b/server/src/main/java/org/eni/koinoniadaily/exceptions/GlobalExceptionHandler.java
@@ -1,11 +1,15 @@
 package org.eni.koinoniadaily.exceptions;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
 import org.eni.koinoniadaily.utils.ErrorResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -15,20 +19,24 @@ import org.springframework.web.context.request.WebRequest;
 import jakarta.persistence.OptimisticLockException;
 
 import java.time.Instant;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @RestControllerAdvice
+@RequiredArgsConstructor
 public class GlobalExceptionHandler {
 
+  private final ObjectMapper objectMapper;
   private static final Logger logger = LoggerFactory.getLogger(GlobalExceptionHandler.class);
 
-  private ResponseEntity<ErrorResponse> buildResponse(WebRequest request, String message, HttpStatus status) {
+  private ResponseEntity<ErrorResponse> buildResponse(WebRequest request, String message, HttpStatus status, String errorCode) {
     ErrorResponse error = ErrorResponse.builder()
                             .success(false)
                             .status(status.value())
                             .error(status.getReasonPhrase())
                             .message(message)
                             .path(((ServletWebRequest) request).getRequest().getRequestURI())
+                            .errorCode(errorCode)
                             .timestamp(Instant.now())
                             .build();
                         
@@ -39,48 +47,59 @@ public class GlobalExceptionHandler {
   @ExceptionHandler(NotFoundException.class)
   public ResponseEntity<ErrorResponse> handleNotFoundException(NotFoundException ex, WebRequest request) {
     
-    return buildResponse(request, ex.getMessage(), HttpStatus.NOT_FOUND);
+    return buildResponse(request, ex.getMessage(), HttpStatus.NOT_FOUND, "RESOURCE_NOT_FOUND");
   }
 
   // Handle validation errors (for @Valid annotated DTOs)
   @ExceptionHandler(MethodArgumentNotValidException.class)
-  public ResponseEntity<ErrorResponse> handleValidationExceptions(MethodArgumentNotValidException ex, WebRequest request) {
+  public ResponseEntity<ErrorResponse> handleValidationException(MethodArgumentNotValidException ex, WebRequest request) {
 
-    String errors = ex.getBindingResult()
-                    .getFieldErrors()
-                    .stream()
-                    .map(err -> err.getField() + ": " + err.getDefaultMessage())
-                    .collect(Collectors.joining(", "));
+    Map<String, String> errors = ex.getBindingResult()
+                                      .getFieldErrors()
+                                      .stream()
+                                      .collect(Collectors.toMap(
+                                          FieldError::getField,
+                                          FieldError::getDefaultMessage,
+                                          (existing, replacement) -> existing
+                                      ));
 
-    return buildResponse(request, errors, HttpStatus.BAD_REQUEST);
+    String message;
+    try {
+      message = objectMapper.writeValueAsString(errors);
+    } catch (JsonProcessingException e) {
+      logger.error("Error serializing validation errors", e);
+      return buildResponse(request, "Validation failed with multiple errors", HttpStatus.UNPROCESSABLE_ENTITY, "VALIDATION_ERROR");
+    }
+
+    return buildResponse(request, message, HttpStatus.UNPROCESSABLE_ENTITY, "VALIDATION_ERROR");
   }
 
   // Handle runtime validation errors
   @ExceptionHandler(ValidationException.class)
   public ResponseEntity<ErrorResponse> handleValidationException(ValidationException ex, WebRequest request) {
      
-    return buildResponse(request, ex.getMessage(), HttpStatus.BAD_REQUEST);
+    return buildResponse(request, ex.getMessage(), HttpStatus.BAD_REQUEST, ex.getCode());
   }
 
   // Handle bad credentials error (for login,..)
   @ExceptionHandler(BadCredentialsException.class)
   public ResponseEntity<ErrorResponse> handleBadCredentialsException(BadCredentialsException ex, WebRequest request) {
 
-    return buildResponse(request, "Invalid credentials", HttpStatus.UNAUTHORIZED);
+    return buildResponse(request, "Invalid credentials", HttpStatus.UNAUTHORIZED, "BAD_CREDENTIALS");
   }
     
   // Handle unauthorized errors
   @ExceptionHandler(UnauthorizedException.class)
   public ResponseEntity<ErrorResponse> handleUnauthorizedException(UnauthorizedException ex, WebRequest request) {
 
-    return buildResponse(request, ex.getMessage(), HttpStatus.UNAUTHORIZED);
+    return buildResponse(request, ex.getMessage(), HttpStatus.UNAUTHORIZED, "UNAUTHORIZED");
   }
     
   // Handle lock exceptions (for token) 
   @ExceptionHandler(OptimisticLockException.class)
   public ResponseEntity<ErrorResponse> handleOptimisticLockException(OptimisticLockException ex, WebRequest request) {
 
-    return buildResponse(request, "Unable to process request due to a conflict. Please try again.", HttpStatus.CONFLICT);
+    return buildResponse(request, "Resource is currently locked. Please try again later.", HttpStatus.CONFLICT, "RESOURCE_LOCKED");
   }
 
   // Handle all other exceptions (catch-all)
@@ -89,6 +108,6 @@ public class GlobalExceptionHandler {
 
     logger.error("Unhandled exception", ex);
         
-    return buildResponse(request, "An unexpected error occurred", HttpStatus.INTERNAL_SERVER_ERROR);
+    return buildResponse(request, "An unexpected error occurred", HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR");
   }
 }

--- a/server/src/main/java/org/eni/koinoniadaily/exceptions/GlobalExceptionHandler.java
+++ b/server/src/main/java/org/eni/koinoniadaily/exceptions/GlobalExceptionHandler.java
@@ -1,6 +1,5 @@
 package org.eni.koinoniadaily.exceptions;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.eni.koinoniadaily.utils.ErrorResponse;
@@ -30,6 +29,10 @@ public class GlobalExceptionHandler {
   private static final Logger logger = LoggerFactory.getLogger(GlobalExceptionHandler.class);
 
   private ResponseEntity<ErrorResponse> buildResponse(WebRequest request, String message, HttpStatus status, String errorCode) {
+    return buildResponse(request, message, status, errorCode, null);
+  }
+
+  private ResponseEntity<ErrorResponse> buildResponse(WebRequest request, String message, HttpStatus status, String errorCode, Object errors) {
     ErrorResponse error = ErrorResponse.builder()
                             .success(false)
                             .status(status.value())
@@ -37,6 +40,7 @@ public class GlobalExceptionHandler {
                             .message(message)
                             .path(((ServletWebRequest) request).getRequest().getRequestURI())
                             .errorCode(errorCode)
+                            .errors(errors)
                             .timestamp(Instant.now())
                             .build();
                         
@@ -59,19 +63,11 @@ public class GlobalExceptionHandler {
                                       .stream()
                                       .collect(Collectors.toMap(
                                           FieldError::getField,
-                                          FieldError::getDefaultMessage,
-                                          (existing, replacement) -> existing
+                                          error -> error.getDefaultMessage() != null ? error.getDefaultMessage() : "Invalid value",
+                                          (existing, replacement) -> existing + ";" + replacement
                                       ));
 
-    String message;
-    try {
-      message = objectMapper.writeValueAsString(errors);
-    } catch (JsonProcessingException e) {
-      logger.error("Error serializing validation errors", e);
-      return buildResponse(request, "Validation failed with multiple errors", HttpStatus.UNPROCESSABLE_ENTITY, "VALIDATION_ERROR");
-    }
-
-    return buildResponse(request, message, HttpStatus.UNPROCESSABLE_ENTITY, "VALIDATION_ERROR");
+    return buildResponse(request, "Validation failed", HttpStatus.UNPROCESSABLE_ENTITY, "VALIDATION_ERROR", errors);
   }
 
   // Handle runtime validation errors

--- a/server/src/main/java/org/eni/koinoniadaily/exceptions/ValidationException.java
+++ b/server/src/main/java/org/eni/koinoniadaily/exceptions/ValidationException.java
@@ -5,10 +5,11 @@ import lombok.Getter;
 @Getter
 public class ValidationException extends RuntimeException {
 
-  private String code = "VALIDATION_ERROR";
+  private final String code;
 
   public ValidationException(String message) {
     super(message);
+    this.code = "VALIDATION_ERROR";
   }
 
   public ValidationException(String code, String message) {

--- a/server/src/main/java/org/eni/koinoniadaily/exceptions/ValidationException.java
+++ b/server/src/main/java/org/eni/koinoniadaily/exceptions/ValidationException.java
@@ -1,7 +1,18 @@
 package org.eni.koinoniadaily.exceptions;
 
+import lombok.Getter;
+
+@Getter
 public class ValidationException extends RuntimeException {
+
+  private String code = "VALIDATION_ERROR";
+
   public ValidationException(String message) {
     super(message);
-  }  
+  }
+
+  public ValidationException(String code, String message) {
+    super(message);
+    this.code = code;
+  }
 }

--- a/server/src/main/java/org/eni/koinoniadaily/modules/account/AccountController.java
+++ b/server/src/main/java/org/eni/koinoniadaily/modules/account/AccountController.java
@@ -15,7 +15,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@RequestMapping("/api/account")
+@RequestMapping("/api/v1/account")
 @RequiredArgsConstructor
 public class AccountController {
   

--- a/server/src/main/java/org/eni/koinoniadaily/modules/auth/AuthController.java
+++ b/server/src/main/java/org/eni/koinoniadaily/modules/auth/AuthController.java
@@ -21,7 +21,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@RequestMapping("/api/auth")
+@RequestMapping("/api/v1/auth")
 @RequiredArgsConstructor
 public class AuthController {
   

--- a/server/src/main/java/org/eni/koinoniadaily/modules/auth/AuthService.java
+++ b/server/src/main/java/org/eni/koinoniadaily/modules/auth/AuthService.java
@@ -49,7 +49,7 @@ public class AuthService {
   public void register(RegisterRequest payload) {
 
     if (userRepository.existsByEmail(payload.getEmail()))  {
-      throw new ValidationException("This email already exists");
+      throw new ValidationException("USER_EMAIL_EXISTS", "This email already exists");
     }
 
     User user = User.builder()
@@ -92,7 +92,7 @@ public class AuthService {
                   .orElseThrow(() -> new NotFoundException("User not found"));
       
     if (user.isVerified()) {
-      throw new ValidationException("User is already verified");
+      throw new ValidationException("USER_ALREADY_VERIFIED", "User is already verified");
     }
     
     tokenService.consumeEmailOtp(user.getEmail(), request.getOtp());
@@ -109,7 +109,7 @@ public class AuthService {
                   .orElseThrow(() -> new NotFoundException("User not found"));
         
     if (user.isVerified()) {
-      throw new ValidationException("User is already verified");
+      throw new ValidationException("USER_ALREADY_VERIFIED", "User is already verified");
     }
 
     String otp = tokenService.generateAndSaveOtp(user.getEmail(), TokenType.VERIFY_EMAIL);

--- a/server/src/main/java/org/eni/koinoniadaily/modules/auth/JwtService.java
+++ b/server/src/main/java/org/eni/koinoniadaily/modules/auth/JwtService.java
@@ -68,9 +68,9 @@ public final class JwtService {
             .parseSignedClaims(token)
             .getPayload();
     } catch (ExpiredJwtException e) {
-      throw new UnauthorizedException("Expired token");
+      throw new UnauthorizedException("Expired token", e);
     } catch (JwtException e) {
-      throw new UnauthorizedException("Invalid token");
+      throw new UnauthorizedException("Invalid token", e);
     }
   }
 

--- a/server/src/main/java/org/eni/koinoniadaily/modules/bookmark/BookmarkController.java
+++ b/server/src/main/java/org/eni/koinoniadaily/modules/bookmark/BookmarkController.java
@@ -25,7 +25,7 @@ import jakarta.validation.constraints.PositiveOrZero;
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@RequestMapping("/api/bookmarks")
+@RequestMapping("/api/v1/bookmarks")
 @RequiredArgsConstructor
 @Validated
 public class BookmarkController {

--- a/server/src/main/java/org/eni/koinoniadaily/modules/bookmark/BookmarkService.java
+++ b/server/src/main/java/org/eni/koinoniadaily/modules/bookmark/BookmarkService.java
@@ -57,7 +57,7 @@ public class BookmarkService {
     Optional<Bookmark> bookmark = bookmarkRepository.findByUserIdAndCategoryIdAndTeachingId(userId, request.getCategoryId(), request.getTeachingId());
 
     if (bookmark.isPresent()) {
-      throw new ValidationException("Teaching already added to the category");
+      throw new ValidationException("TEACHING_ALREADY_ADDED", "Teaching already added to the category");
     }
 
     User user = userRepository.getReferenceById(userId);

--- a/server/src/main/java/org/eni/koinoniadaily/modules/bookmarkcategory/BookmarkCategoryController.java
+++ b/server/src/main/java/org/eni/koinoniadaily/modules/bookmarkcategory/BookmarkCategoryController.java
@@ -24,7 +24,7 @@ import jakarta.validation.constraints.PositiveOrZero;
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@RequestMapping("/api/bookmark-categories")
+@RequestMapping("/api/v1/bookmark-categories")
 @RequiredArgsConstructor
 @Validated
 public class BookmarkCategoryController {

--- a/server/src/main/java/org/eni/koinoniadaily/modules/collection/CollectionController.java
+++ b/server/src/main/java/org/eni/koinoniadaily/modules/collection/CollectionController.java
@@ -27,7 +27,7 @@ import jakarta.validation.constraints.PositiveOrZero;
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@RequestMapping("/api/collections")
+@RequestMapping("/api/v1/collections")
 @RequiredArgsConstructor
 @Validated
 public class CollectionController {

--- a/server/src/main/java/org/eni/koinoniadaily/modules/file/FileController.java
+++ b/server/src/main/java/org/eni/koinoniadaily/modules/file/FileController.java
@@ -19,7 +19,7 @@ import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/file")
+@RequestMapping("/api/v1/file")
 @Validated
 public class FileController {
   

--- a/server/src/main/java/org/eni/koinoniadaily/modules/history/HistoryController.java
+++ b/server/src/main/java/org/eni/koinoniadaily/modules/history/HistoryController.java
@@ -22,7 +22,7 @@ import jakarta.validation.constraints.PositiveOrZero;
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@RequestMapping("/api/histories")
+@RequestMapping("/api/v1/histories")
 @RequiredArgsConstructor
 @Validated
 public class HistoryController {

--- a/server/src/main/java/org/eni/koinoniadaily/modules/series/SeriesController.java
+++ b/server/src/main/java/org/eni/koinoniadaily/modules/series/SeriesController.java
@@ -26,7 +26,7 @@ import jakarta.validation.constraints.PositiveOrZero;
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@RequestMapping("/api/series")
+@RequestMapping("/api/v1/series")
 @RequiredArgsConstructor
 @Validated
 public class SeriesController {

--- a/server/src/main/java/org/eni/koinoniadaily/modules/teaching/TeachingController.java
+++ b/server/src/main/java/org/eni/koinoniadaily/modules/teaching/TeachingController.java
@@ -27,7 +27,7 @@ import jakarta.validation.constraints.PositiveOrZero;
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@RequestMapping("/api/teachings")
+@RequestMapping("/api/v1/teachings")
 @RequiredArgsConstructor
 @Validated
 public class TeachingController {

--- a/server/src/main/java/org/eni/koinoniadaily/modules/transcript/TranscriptController.java
+++ b/server/src/main/java/org/eni/koinoniadaily/modules/transcript/TranscriptController.java
@@ -27,7 +27,7 @@ import jakarta.validation.constraints.PositiveOrZero;
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@RequestMapping("/api/transcripts")
+@RequestMapping("/api/v1/transcripts")
 @RequiredArgsConstructor
 @Validated
 @PreAuthorize("hasAuthority('ADMIN')")

--- a/server/src/main/java/org/eni/koinoniadaily/utils/ErrorResponse.java
+++ b/server/src/main/java/org/eni/koinoniadaily/utils/ErrorResponse.java
@@ -5,7 +5,7 @@ import java.time.Instant;
 import lombok.Getter;
 import lombok.experimental.SuperBuilder;
 
-@Getter
+//@Getter
 @SuperBuilder
 public class ErrorResponse extends ApiResponse {
   
@@ -14,6 +14,8 @@ public class ErrorResponse extends ApiResponse {
   private final String error;
   
   private final String path;
-  
+
+  private final String errorCode;
+
   private final Instant timestamp;
 }

--- a/server/src/main/java/org/eni/koinoniadaily/utils/ErrorResponse.java
+++ b/server/src/main/java/org/eni/koinoniadaily/utils/ErrorResponse.java
@@ -5,7 +5,7 @@ import java.time.Instant;
 import lombok.Getter;
 import lombok.experimental.SuperBuilder;
 
-//@Getter
+@Getter
 @SuperBuilder
 public class ErrorResponse extends ApiResponse {
   
@@ -16,6 +16,8 @@ public class ErrorResponse extends ApiResponse {
   private final String path;
 
   private final String errorCode;
+
+  private final Object errors;
 
   private final Instant timestamp;
 }


### PR DESCRIPTION
### What was changed
- change `/api` to `/api/v1`
- add errorCode field to ErrorResponse class

### Why it was changed
- apply versioning
- consistent error response format, with Machine readable code

### How it was implemented
- basic implementation
- change request validation message shape to use objectMaper with `Map<String, String>` 

### Linked Issue
Closing #97  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API error payloads now include standardized error codes (e.g., VALIDATION_ERROR, RATE_LIMIT_EXCEEDED, RESOURCE_NOT_FOUND) and optional per-field error details.
  * Rate-limit and auth failures return consistent errorCode fields for easier client handling.

* **Chores**
  * All API routes versioned to /api/v1/.
  * Error response format standardized across endpoints for consistent client parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->