### PR TITLE
feat(forgot-password): setup ui and logic

### DIFF
--- a/mobile/app/(auth)/_layout.tsx
+++ b/mobile/app/(auth)/_layout.tsx
@@ -20,6 +20,7 @@ const GuestLayout = () => {
       <Stack.Screen name="login" options={{ headerShown: false }} />
       <Stack.Screen name="register" options={{ headerShown: false }} />
       <Stack.Screen name="verify-email" options={{ headerShown: false }} />
+      <Stack.Screen name="forgot-password" options={{ headerTitle: '', headerShown: true }} />
     </Stack>
   );
 };

--- a/mobile/app/(auth)/forgot-password.tsx
+++ b/mobile/app/(auth)/forgot-password.tsx
@@ -1,0 +1,6 @@
+import ForgotPassword from '@/screens/auth/forgot-password';
+import React from 'react';
+
+export default function ForgotPasswordScreen() {
+  return <ForgotPassword />;
+}

--- a/mobile/app/(auth)/reset-password.tsx
+++ b/mobile/app/(auth)/reset-password.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { Text, View } from 'react-native';
+
+export default function ResetPasswordScreen() {
+  return (
+    <View>
+      <Text>ResetPasswordScreen</Text>
+    </View>
+  );
+}

--- a/mobile/features/auth/hook.ts
+++ b/mobile/features/auth/hook.ts
@@ -3,9 +3,9 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 import { useRouter } from 'expo-router';
 import { Alert } from 'react-native';
-import { login, logout, register, requestOtp, verifyEmail } from './api';
+import { forgotPassword, login, logout, register, requestOtp, verifyEmail } from './api';
 import { useAuth } from './auth-context';
-import type { LoginSchema, LogoutSchema, RegisterSchema, VerifyEmailSchema } from './schema';
+import type { ForgotPasswordSchema, LoginSchema, LogoutSchema, RegisterSchema, VerifyEmailSchema } from './schema';
 import { useAuthStore } from './store';
 
 const useRegister = () => {
@@ -70,7 +70,6 @@ const useVerifyEmail = () => {
     mutationFn: (payload: VerifyEmailSchema) => verifyEmail(payload),
     onSuccess: (data) => {
       if (!credentials) {
-        Alert.alert('Error', 'No credentials found for login');
         router.push('/login');
         return;
       }
@@ -104,6 +103,20 @@ const useRequestOtp = () => {
   });
 };
 
+const useForgotPassword = () => {
+  const router = useRouter();
+
+  return useMutation({
+    mutationFn: (payload: ForgotPasswordSchema) => forgotPassword(payload),
+    onSuccess: (data) => {
+      router.replace('/reset-password');
+    },
+    onError: (data: AxiosError<ErrorResponse>) => {
+      Alert.alert('Request Failed', data.response?.data?.message || data.message);
+    },
+  });
+};
+
 const useLogout = () => {
   const queryClient = useQueryClient();
   const { logout: authLogout } = useAuth();
@@ -123,4 +136,5 @@ const useLogout = () => {
   });
 };
 
-export { useLogin, useLogout, useRegister, useRequestOtp, useVerifyEmail };
+export { useForgotPassword, useLogin, useLogout, useRegister, useRequestOtp, useVerifyEmail };
+

--- a/mobile/features/auth/hook.ts
+++ b/mobile/features/auth/hook.ts
@@ -108,8 +108,8 @@ const useForgotPassword = () => {
 
   return useMutation({
     mutationFn: (payload: ForgotPasswordSchema) => forgotPassword(payload),
-    onSuccess: (data) => {
-      router.replace('/reset-password');
+    onSuccess: (data, variables) => {
+      router.replace({ pathname: '/reset-password', params: { email: variables.email } });
     },
     onError: (data: AxiosError<ErrorResponse>) => {
       Alert.alert('Request Failed', data.response?.data?.message || data.message);
@@ -137,4 +137,3 @@ const useLogout = () => {
 };
 
 export { useForgotPassword, useLogin, useLogout, useRegister, useRequestOtp, useVerifyEmail };
-

--- a/mobile/screens/auth/forgot-password.tsx
+++ b/mobile/screens/auth/forgot-password.tsx
@@ -1,0 +1,91 @@
+import { Button } from '@/components/reusables/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/reusables/ui/card';
+import { Input } from '@/components/reusables/ui/input';
+import { Label } from '@/components/reusables/ui/label';
+import GoldGradient from '@/components/ui/gold-gradient';
+import { useForgotPassword } from '@/features/auth/hook';
+import { forgotPasswordSchema, type ForgotPasswordSchema } from '@/features/auth/schema';
+import useForm from '@/hooks/use-app-form';
+import { useLocalSearchParams } from 'expo-router';
+import React from 'react';
+import {
+    ActivityIndicator,
+    KeyboardAvoidingView,
+    Platform,
+    ScrollView,
+    Text,
+    useColorScheme,
+    View,
+} from 'react-native';
+
+const ForgotPassword = () => {
+  const colorScheme = useColorScheme();
+  const { email } = useLocalSearchParams<{ email: string }>();
+  const { mutate: forgotPassword, isPending } = useForgotPassword();
+  const { form, errors, handleChange, handleSubmit } = useForm<ForgotPasswordSchema>({
+    data: {
+      email,
+    },
+    schema: forgotPasswordSchema,
+    onSubmit: (data) => forgotPassword(data),
+  });
+
+  return (
+    <KeyboardAvoidingView
+      className="flex-1"
+      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+      keyboardVerticalOffset={Platform.OS === 'ios' ? 80 : 0}
+    >
+      <ScrollView
+        keyboardShouldPersistTaps="handled"
+        contentContainerClassName="sm:flex-1 items-center justify-center p-4 py-8 sm:py-4 sm:p-6 mt-safe"
+        keyboardDismissMode="interactive"
+      >
+        <View className="w-full max-w-sm">
+          <View className="gap-6">
+            <Card className="bg-transparent border-0">
+              <CardHeader>
+                <CardTitle className="text-center text-gold-text text-xl sm:text-left">Sign in to your app</CardTitle>
+                <CardDescription className="text-center sm:text-left">
+                  Yeah! It happens. We&apos;ve got your back. Simply supply your registered email below and you&apos;ll be
+                  set to go.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="gap-6">
+                <View className="gap-6">
+                  <View className="gap-1.5">
+                    <Label htmlFor="email">Email</Label>
+                    <Input
+                      id="email"
+                      placeholder="m@example.com"
+                      keyboardType="email-address"
+                      autoComplete="email"
+                      autoCapitalize="none"
+                      editable={!isPending}
+                      value={form.email}
+                      onChangeText={(text) => handleChange('email', text)}
+                      returnKeyType="next"
+                      submitBehavior="submit"
+                    />
+                    {errors?.email && <Text className="text-sm text-destructive">{errors?.email}</Text>}
+                  </View>
+                  <GoldGradient>
+                    <Button className="bg-transparent w-full" onPress={handleSubmit} disabled={isPending}>
+                      {isPending ? (
+                        <ActivityIndicator color={colorScheme === 'dark' ? '#000000' : '#ffffff'} />
+                      ) : (
+                        <Text>Continue</Text>
+                      )}
+                    </Button>
+                  </GoldGradient>
+                </View>
+              </CardContent>
+            </Card>
+          </View>
+        </View>
+      </ScrollView>
+    </KeyboardAvoidingView>
+  );
+};
+
+export default ForgotPassword;

--- a/mobile/screens/auth/forgot-password.tsx
+++ b/mobile/screens/auth/forgot-password.tsx
@@ -9,22 +9,22 @@ import useForm from '@/hooks/use-app-form';
 import { useLocalSearchParams } from 'expo-router';
 import React from 'react';
 import {
-    ActivityIndicator,
-    KeyboardAvoidingView,
-    Platform,
-    ScrollView,
-    Text,
-    useColorScheme,
-    View,
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  Text,
+  useColorScheme,
+  View,
 } from 'react-native';
 
 const ForgotPassword = () => {
   const colorScheme = useColorScheme();
-  const { email } = useLocalSearchParams<{ email: string }>();
+  const { email } = useLocalSearchParams<{ email?: string }>();
   const { mutate: forgotPassword, isPending } = useForgotPassword();
   const { form, errors, handleChange, handleSubmit } = useForm<ForgotPasswordSchema>({
     data: {
-      email,
+      email: email ?? '',
     },
     schema: forgotPasswordSchema,
     onSubmit: (data) => forgotPassword(data),
@@ -45,10 +45,10 @@ const ForgotPassword = () => {
           <View className="gap-6">
             <Card className="bg-transparent border-0">
               <CardHeader>
-                <CardTitle className="text-center text-gold-text text-xl sm:text-left">Sign in to your app</CardTitle>
+                <CardTitle className="text-center text-gold-text text-xl sm:text-left">Forgot Password</CardTitle>
                 <CardDescription className="text-center sm:text-left">
-                  Yeah! It happens. We&apos;ve got your back. Simply supply your registered email below and you&apos;ll be
-                  set to go.
+                  Yeah! It happens. We&apos;ve got your back. Simply supply your registered email below and you&apos;ll
+                  be set to go.
                 </CardDescription>
               </CardHeader>
               <CardContent className="gap-6">

--- a/mobile/screens/auth/login.tsx
+++ b/mobile/screens/auth/login.tsx
@@ -83,9 +83,7 @@ const Login = () => {
                         variant="link"
                         size="sm"
                         className="ml-auto h-4 px-1 py-0 sm:h-4"
-                        onPress={() => {
-                          // TODO: Navigate to forgot password screen
-                        }}
+                        onPress={() => router.push({ pathname: '/forgot-password', params: { email: form.email } })}
                       >
                         <Text className="text-gold-text font-normal leading-4">Forgot your password?</Text>
                       </Button>


### PR DESCRIPTION
## 📌 Summary

<!-- What does this PR do? Be specific. -->
- It will setup the UI screen for the forget-password with the API logic intergration.
- It will use form validation for the email and also attach the current email input from login screen to the forgot-password route, so it can auto-populate the email field. 
- it will also create a dummy screen for the reset password for the redirection after form submission.

---

## 🎯 Why is this change needed?

<!-- Link to issue or explain business reason -->
Closes #78

---

## 🧠 What was changed?

<!-- High-level technical explanation -->
- adds forgot-password screen and integrate API logic 

---

## 🏗️ Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Performance improvement
- [ ] Security fix
- [ ] Documentation update
- [ ] Test improvement
- [ ] Breaking change

---

## 🧪 How was this tested?

<!-- Explain test coverage -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing
- [ ] Postman tested
- [ ] Not tested (explain why)

Test details:
- Normal manual check 

---

## 📸 Screenshots / API Samples (if applicable)

<!-- Example request/response or UI screenshot -->
![Screenshot_20260226_205321_Expo Go.png](https://github.com/user-attachments/assets/623fed3b-3c5c-47ac-a31b-118b753fd8fc)





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a complete Forgot Password flow with email validation, error handling, and loading states.
  * Introduced a Reset Password screen to support account recovery.
  * Added a new hook to submit forgot-password requests and navigate on success.
  * Updated login to navigate to Forgot Password and improved keyboard handling for mobile.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->