### PR TITLE
feat(reset-password): setup ui & integrate logic

### DIFF
--- a/mobile/app/(auth)/_layout.tsx
+++ b/mobile/app/(auth)/_layout.tsx
@@ -21,6 +21,7 @@ const GuestLayout = () => {
       <Stack.Screen name="register" options={{ headerShown: false }} />
       <Stack.Screen name="verify-email" options={{ headerShown: false }} />
       <Stack.Screen name="forgot-password" options={{ headerTitle: '', headerShown: true }} />
+      <Stack.Screen name="reset-password" options={{ headerTitle: '', headerShown: true }} />
     </Stack>
   );
 };

--- a/mobile/app/(auth)/reset-password.tsx
+++ b/mobile/app/(auth)/reset-password.tsx
@@ -1,10 +1,6 @@
+import ResetPassword from '@/screens/auth/reset-password';
 import React from 'react';
-import { Text, View } from 'react-native';
 
 export default function ResetPasswordScreen() {
-  return (
-    <View>
-      <Text>ResetPasswordScreen</Text>
-    </View>
-  );
+  return <ResetPassword />;
 }

--- a/mobile/components/reusables/ui/button.tsx
+++ b/mobile/components/reusables/ui/button.tsx
@@ -2,6 +2,7 @@ import { TextClassContext } from '@/components/reusables/ui/text';
 import { cn } from '@/lib/utils';
 import { cva, type VariantProps } from 'class-variance-authority';
 import { Platform, Pressable } from 'react-native';
+import ScalePressable from './scale-pressable';
 
 const buttonVariants = cva(
   cn(
@@ -92,7 +93,7 @@ type ButtonProps = React.ComponentProps<typeof Pressable> &
 function Button({ className, variant, size, ...props }: ButtonProps) {
   return (
     <TextClassContext.Provider value={buttonTextVariants({ variant, size })}>
-      <Pressable
+      <ScalePressable
         className={cn(props.disabled && 'opacity-50', buttonVariants({ variant, size }), className)}
         role="button"
         {...props}
@@ -103,3 +104,4 @@ function Button({ className, variant, size, ...props }: ButtonProps) {
 
 export { Button, buttonTextVariants, buttonVariants };
 export type { ButtonProps };
+

--- a/mobile/components/reusables/ui/scale-pressable.tsx
+++ b/mobile/components/reusables/ui/scale-pressable.tsx
@@ -1,0 +1,38 @@
+import React, { useRef, type ReactNode } from 'react';
+import { Animated, Pressable } from 'react-native';
+
+const ScalePressable = ({
+  onPressIn: _,
+  onPressOut: __,
+  style,
+  children,
+  ...props
+}: React.ComponentProps<typeof Pressable> & React.RefAttributes<typeof Pressable>) => {
+  const scale = useRef(new Animated.Value(1)).current;
+
+  const animateIn = () => {
+    Animated.spring(scale, {
+      toValue: 0.9,
+      useNativeDriver: true,
+      speed: 20,
+      bounciness: 0,
+    }).start();
+  };
+
+  const animateOut = () => {
+    Animated.spring(scale, {
+      toValue: 1,
+      useNativeDriver: true,
+      speed: 20,
+      bounciness: 4,
+    }).start();
+  };
+
+  return (
+    <Pressable onPressIn={animateIn} onPressOut={animateOut} style={style} {...props}>
+      <Animated.View style={{ transform: [{ scale }] }}>{children as ReactNode}</Animated.View>
+    </Pressable>
+  );
+};
+
+export default ScalePressable;

--- a/mobile/components/reusables/ui/scale-pressable.tsx
+++ b/mobile/components/reusables/ui/scale-pressable.tsx
@@ -2,9 +2,8 @@ import React, { useRef, type ReactNode } from 'react';
 import { Animated, Pressable } from 'react-native';
 
 const ScalePressable = ({
-  onPressIn: _,
-  onPressOut: __,
-  style,
+  onPressIn,
+  onPressOut,
   children,
   ...props
 }: React.ComponentProps<typeof Pressable> & React.RefAttributes<typeof Pressable>) => {
@@ -28,8 +27,18 @@ const ScalePressable = ({
     }).start();
   };
 
+  const handlePressIn: React.ComponentProps<typeof Pressable>['onPressIn'] = (event) => {
+    animateIn();
+    onPressIn?.(event);
+  };
+
+  const handlePressOut: React.ComponentProps<typeof Pressable>['onPressOut'] = (event) => {
+    animateOut();
+    onPressOut?.(event);
+  };
+
   return (
-    <Pressable onPressIn={animateIn} onPressOut={animateOut} style={style} {...props}>
+    <Pressable onPressIn={handlePressIn} onPressOut={handlePressOut} {...props}>
       <Animated.View style={{ transform: [{ scale }] }}>{children as ReactNode}</Animated.View>
     </Pressable>
   );

--- a/mobile/components/ui/bottom-sheet.tsx
+++ b/mobile/components/ui/bottom-sheet.tsx
@@ -1,0 +1,61 @@
+import type { ReactNode } from 'react';
+import { Modal, Pressable, ScrollView, Text, useWindowDimensions, View } from 'react-native';
+
+interface BottomSheetProps {
+  children: ReactNode;
+  isOpen: boolean;
+  onClose?: () => void;
+  title?: string;
+}
+
+const BottomSheet = ({ children, isOpen, onClose, title }: BottomSheetProps) => {
+  const { height: SCREEN_HEIGHT } = useWindowDimensions();
+
+  return (
+    <Modal transparent visible={isOpen} animationType="slide" onRequestClose={onClose}>
+      <View style={{ flex: 1, justifyContent: 'flex-end' }}>
+        {/* Backdrop */}
+        <Pressable
+          style={{ position: 'absolute', top: 0, bottom: 0, left: 0, right: 0, backgroundColor: 'rgba(0,0,0,0.5)' }}
+          onPress={onClose}
+        />
+
+        {/* Sheet Content */}
+        <View
+          style={{
+            // backgroundColor: colors.containerBackground,
+            borderTopLeftRadius: 24,
+            borderTopRightRadius: 24,
+            paddingTop: 12,
+            paddingBottom: 40,
+            maxHeight: SCREEN_HEIGHT * 0.6,
+            width: '100%',
+          }}
+        >
+          {/* Handle */}
+          <View
+            style={{
+              width: 40,
+              height: 4,
+              borderRadius: 2,
+              alignSelf: 'center',
+              marginBottom: 16,
+            }}
+          />
+
+          {title && (
+            <View style={{ paddingHorizontal: 20, marginBottom: 16 }}>
+              <Text className="text-xl font-bold">{title}</Text>
+            </View>
+          )}
+
+          <ScrollView showsVerticalScrollIndicator={false} className="px-4">
+            {children}
+          </ScrollView>
+        </View>
+      </View>
+    </Modal>
+  );
+};
+
+export default BottomSheet;

--- a/mobile/components/ui/bottom-sheet.tsx
+++ b/mobile/components/ui/bottom-sheet.tsx
@@ -37,6 +37,7 @@ const BottomSheet = ({ children, isOpen, onClose, title }: BottomSheetProps) => 
           {/* Handle */}
           <View
             style={{
+              backgroundColor: Colors[colorScheme ?? 'light'].text,
               width: 40,
               height: 4,
               borderRadius: 2,

--- a/mobile/components/ui/bottom-sheet.tsx
+++ b/mobile/components/ui/bottom-sheet.tsx
@@ -1,5 +1,6 @@
+import { Colors } from '@/constants/theme';
 import type { ReactNode } from 'react';
-import { Modal, Pressable, ScrollView, Text, useWindowDimensions, View } from 'react-native';
+import { Modal, Pressable, ScrollView, Text, useColorScheme, useWindowDimensions, View } from 'react-native';
 
 interface BottomSheetProps {
   children: ReactNode;
@@ -9,6 +10,7 @@ interface BottomSheetProps {
 }
 
 const BottomSheet = ({ children, isOpen, onClose, title }: BottomSheetProps) => {
+  const colorScheme = useColorScheme();
   const { height: SCREEN_HEIGHT } = useWindowDimensions();
 
   return (
@@ -23,7 +25,7 @@ const BottomSheet = ({ children, isOpen, onClose, title }: BottomSheetProps) => 
         {/* Sheet Content */}
         <View
           style={{
-            // backgroundColor: colors.containerBackground,
+            backgroundColor: Colors[colorScheme ?? 'light'].background,
             borderTopLeftRadius: 24,
             borderTopRightRadius: 24,
             paddingTop: 12,

--- a/mobile/components/ui/icon-symbol.tsx
+++ b/mobile/components/ui/icon-symbol.tsx
@@ -17,6 +17,8 @@ const MAPPING = {
   'paperplane.fill': 'send',
   'chevron.left.forwardslash.chevron.right': 'code',
   'chevron.right': 'chevron-right',
+  'checkmark.circle': 'check',
+  'arrow.forward': 'arrow-forward',
 } satisfies IconMapping;
 
 type IconSymbolName = keyof typeof MAPPING;
@@ -31,12 +33,14 @@ export function IconSymbol({
   size = 24,
   color,
   style,
+  className = '',
 }: {
   name: IconSymbolName;
   size?: number;
   color: string | OpaqueColorValue;
   style?: StyleProp<TextStyle>;
   weight?: SymbolWeight;
+  className?: string;
 }) {
-  return <MaterialIcons color={color} size={size} name={MAPPING[name]} style={style} />;
+  return <MaterialIcons color={color} size={size} name={MAPPING[name]} style={style} className={className} />;
 }

--- a/mobile/constants/theme.ts
+++ b/mobile/constants/theme.ts
@@ -34,6 +34,7 @@ export const Colors = {
   lightPrimary: '#EDEAF5',
   secondary: '#E6E2F3',
   tertiary: '#E03971',
+  icon: 'hsl(48 80% 50%)', // 48 80% 50%
 };
 
 export const Fonts = Platform.select({

--- a/mobile/constants/theme.ts
+++ b/mobile/constants/theme.ts
@@ -34,7 +34,7 @@ export const Colors = {
   lightPrimary: '#EDEAF5',
   secondary: '#E6E2F3',
   tertiary: '#E03971',
-  icon: 'hsl(48 80% 50%)', // 48 80% 50%
+  goldIcon: 'hsl(48 80% 50%)',
 };
 
 export const Fonts = Platform.select({

--- a/mobile/features/auth/hook.ts
+++ b/mobile/features/auth/hook.ts
@@ -3,9 +3,16 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 import { useRouter } from 'expo-router';
 import { Alert } from 'react-native';
-import { forgotPassword, login, logout, register, requestOtp, verifyEmail } from './api';
+import { forgotPassword, login, logout, register, requestOtp, resetPassword, verifyEmail } from './api';
 import { useAuth } from './auth-context';
-import type { ForgotPasswordSchema, LoginSchema, LogoutSchema, RegisterSchema, VerifyEmailSchema } from './schema';
+import type {
+  ForgotPasswordSchema,
+  LoginSchema,
+  LogoutSchema,
+  RegisterSchema,
+  ResetPasswordSchema,
+  VerifyEmailSchema,
+} from './schema';
 import { useAuthStore } from './store';
 
 const useRegister = () => {
@@ -117,6 +124,16 @@ const useForgotPassword = () => {
   });
 };
 
+const useResetPassword = () => {
+  return useMutation({
+    mutationFn: (payload: ResetPasswordSchema) => resetPassword(payload),
+    onSuccess: (data) => data,
+    onError: (data: AxiosError<ErrorResponse>) => {
+      Alert.alert('Request failed', data.response?.data?.message || data.message);
+    },
+  });
+};
+
 const useLogout = () => {
   const queryClient = useQueryClient();
   const { logout: authLogout } = useAuth();
@@ -136,4 +153,5 @@ const useLogout = () => {
   });
 };
 
-export { useForgotPassword, useLogin, useLogout, useRegister, useRequestOtp, useVerifyEmail };
+export { useForgotPassword, useLogin, useLogout, useRegister, useRequestOtp, useResetPassword, useVerifyEmail };
+

--- a/mobile/features/auth/hook.ts
+++ b/mobile/features/auth/hook.ts
@@ -69,19 +69,9 @@ const useLogin = () => {
 };
 
 const useVerifyEmail = () => {
-  const { mutate: login } = useLogin();
-  const { credentials } = useAuthStore();
-  const router = useRouter();
-
   return useMutation({
     mutationFn: (payload: VerifyEmailSchema) => verifyEmail(payload),
-    onSuccess: (data) => {
-      if (!credentials) {
-        router.push('/login');
-        return;
-      }
-      login({ email: credentials.email, password: credentials.password });
-    },
+    onSuccess: (data) => data,
     onError: (data: AxiosError<ErrorResponse>) => {
       Alert.alert('Verification failed', data.response?.data?.message || data.message);
     },

--- a/mobile/screens/auth/forgot-password.tsx
+++ b/mobile/screens/auth/forgot-password.tsx
@@ -74,7 +74,7 @@ const ForgotPassword = () => {
                       {isPending ? (
                         <ActivityIndicator color={colorScheme === 'dark' ? '#000000' : '#ffffff'} />
                       ) : (
-                        <Text>Continue</Text>
+                        <Text>Request Code</Text>
                       )}
                     </Button>
                   </GoldGradient>

--- a/mobile/screens/auth/login.tsx
+++ b/mobile/screens/auth/login.tsx
@@ -85,9 +85,9 @@ const Login = () => {
                     <View className="flex-row items-center">
                       <Label htmlFor="password">Password</Label>
                       <Button
-                        variant="link"
+                        variant="ghost"
                         size="sm"
-                        className="ml-auto h-4 px-1 py-0 sm:h-4"
+                        className="ml-auto h-4 px-1 py-0 sm:h-4 no-underline"
                         onPress={() => router.push({ pathname: '/forgot-password', params: { email: form.email } })}
                       >
                         <Text className="text-gold-text font-normal leading-4">Forgot your password?</Text>
@@ -101,6 +101,7 @@ const Login = () => {
                       value={form.password}
                       onChangeText={(text) => handleChange('password', text)}
                       ref={passwordRef}
+                      onSubmitEditing={handleSubmit}
                     />
                     {errors?.password && <Text className="text-sm text-destructive">{errors?.password}</Text>}
                   </View>

--- a/mobile/screens/auth/login.tsx
+++ b/mobile/screens/auth/login.tsx
@@ -10,6 +10,8 @@ import { useLogin } from '@/features/auth/hook';
 import { type LoginSchema, loginSchema } from '@/features/auth/schema';
 import useForm from '@/hooks/use-app-form';
 import { router } from 'expo-router';
+import { useRef } from 'react';
+import type { TextInput } from 'react-native';
 import {
   ActivityIndicator,
   Image,
@@ -32,6 +34,8 @@ const Login = () => {
     schema: loginSchema,
     onSubmit: (data) => login(data),
   });
+
+  const passwordRef = useRef<TextInput>(null);
 
   const handleSocialSignIn = (type: string) => {
     // TODO
@@ -68,11 +72,12 @@ const Login = () => {
                       keyboardType="email-address"
                       autoComplete="email"
                       autoCapitalize="none"
+                      returnKeyType="next"
+                      submitBehavior="submit"
                       editable={!isPending}
                       value={form.email}
                       onChangeText={(text) => handleChange('email', text)}
-                      returnKeyType="next"
-                      submitBehavior="submit"
+                      onSubmitEditing={() => passwordRef.current?.focus()}
                     />
                     {errors?.email && <Text className="text-sm text-destructive">{errors?.email}</Text>}
                   </View>
@@ -95,6 +100,7 @@ const Login = () => {
                       editable={!isPending}
                       value={form.password}
                       onChangeText={(text) => handleChange('password', text)}
+                      ref={passwordRef}
                     />
                     {errors?.password && <Text className="text-sm text-destructive">{errors?.password}</Text>}
                   </View>

--- a/mobile/screens/auth/login.tsx
+++ b/mobile/screens/auth/login.tsx
@@ -105,7 +105,7 @@ const Login = () => {
                     {errors?.password && <Text className="text-sm text-destructive">{errors?.password}</Text>}
                   </View>
                   <GoldGradient>
-                    <Button className="bg-transparent w-full" onPress={handleSubmit} disabled={isPending}>
+                    <Button className="bg-transparent w-full font-semibold" onPress={handleSubmit} disabled={isPending}>
                       {isPending ? (
                         <ActivityIndicator color={colorScheme === 'dark' ? '#000000' : '#ffffff'} />
                       ) : (

--- a/mobile/screens/auth/register.tsx
+++ b/mobile/screens/auth/register.tsx
@@ -151,7 +151,7 @@ const Register = () => {
                   </View>
                   <GoldGradient>
                     <Button
-                      className="bg-transparent w-full"
+                      className="bg-transparent w-full font-semibold"
                       onPress={handleSubmit}
                       disabled={isPending || confirmPassword !== form.password}
                     >

--- a/mobile/screens/auth/reset-password.tsx
+++ b/mobile/screens/auth/reset-password.tsx
@@ -45,7 +45,12 @@ const ResetPassword = () => {
       router.replace('/login');
       return;
     }
-    login({ email: form.email, password: form.password });
+    login(
+      { email: form.email, password: form.password },
+      {
+        onError: () => router.replace('/login'),
+      }
+    );
   };
 
   useEffect(() => {
@@ -113,7 +118,9 @@ const ResetPassword = () => {
                   <GoldGradient>
                     <Button className="bg-transparent w-full font-semibold" onPress={handleSubmit} disabled={isPending}>
                       {isPending ? (
-                        <ActivityIndicator color={colorScheme === 'dark' ? '#000000' : '#ffffff'} />
+                        <ActivityIndicator
+                          color={colorScheme === 'dark' ? Colors.dark.background : Colors.light.background}
+                        />
                       ) : (
                         <Text>Reset Password</Text>
                       )}
@@ -125,9 +132,14 @@ const ResetPassword = () => {
           </View>
         </View>
       </ScrollView>
+
       <BottomSheet isOpen={isModalOpen} onClose={handleCompleteModal}>
         <GoldGradient className="w-16 h-16 rounded-full items-center justify-center self-center mb-8">
-          <IconSymbol name="checkmark.circle" size={40} color={colorScheme === 'dark' ? '#000000' : '#ffffff'} />
+          <IconSymbol
+            name="checkmark.circle"
+            size={40}
+            color={colorScheme === 'dark' ? Colors.dark.background : Colors.light.background}
+          />
         </GoldGradient>
         <ThemedText className="text-center text-2xl">Password reset successfully!</ThemedText>
         <Button

--- a/mobile/screens/auth/reset-password.tsx
+++ b/mobile/screens/auth/reset-password.tsx
@@ -4,6 +4,7 @@ import { Input } from '@/components/reusables/ui/input';
 import { Label } from '@/components/reusables/ui/label';
 import BottomSheet from '@/components/ui/bottom-sheet';
 import GoldGradient from '@/components/ui/gold-gradient';
+import { IconSymbol } from '@/components/ui/icon-symbol';
 import { useLogin, useResetPassword } from '@/features/auth/hook';
 import { resetPasswordSchema, type ResetPasswordSchema } from '@/features/auth/schema';
 import useForm from '@/hooks/use-app-form';
@@ -125,9 +126,18 @@ const ResetPassword = () => {
         </View>
       </ScrollView>
       <BottomSheet isOpen={isModalOpen}>
-        <Text>Hello There</Text>
+        <View className="bg-green-100 w-16 h-16 rounded-full items-center justify-center self-center mb-4">
+          <IconSymbol name="checkmark.circle" size={24} color="#047857" />
+        </View>
+        <Text className="text-center">Password reset successfully!</Text>
         <Button className="bg-transparent w-full" onPress={handleCompleteModal}>
           <Text>Continue</Text>
+          <IconSymbol
+            name="arrow.forward"
+            size={16}
+            className="ml-2"
+            color={colorScheme === 'dark' ? '#000000' : '#ffffff'}
+          />
         </Button>
       </BottomSheet>
     </KeyboardAvoidingView>

--- a/mobile/screens/auth/reset-password.tsx
+++ b/mobile/screens/auth/reset-password.tsx
@@ -2,9 +2,11 @@ import { Button } from '@/components/reusables/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/reusables/ui/card';
 import { Input } from '@/components/reusables/ui/input';
 import { Label } from '@/components/reusables/ui/label';
+import { ThemedText } from '@/components/themed-text';
 import BottomSheet from '@/components/ui/bottom-sheet';
 import GoldGradient from '@/components/ui/gold-gradient';
 import { IconSymbol } from '@/components/ui/icon-symbol';
+import { Colors } from '@/constants/theme';
 import { useLogin, useResetPassword } from '@/features/auth/hook';
 import { resetPasswordSchema, type ResetPasswordSchema } from '@/features/auth/schema';
 import useForm from '@/hooks/use-app-form';
@@ -12,13 +14,13 @@ import { router, useLocalSearchParams } from 'expo-router';
 import React, { useEffect, useRef, useState } from 'react';
 import type { TextInput } from 'react-native';
 import {
-    ActivityIndicator,
-    KeyboardAvoidingView,
-    Platform,
-    ScrollView,
-    Text,
-    useColorScheme,
-    View,
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  Text,
+  useColorScheme,
+  View,
 } from 'react-native';
 
 const ResetPassword = () => {
@@ -53,9 +55,14 @@ const ResetPassword = () => {
     login({ email: form.email, password: form.password });
   };
 
+  useEffect(() => {
+    if (!email) {
+      router.replace('/forgot-password');
+    }
+  }, [email]);
+
   if (!email) {
-    router.replace('/forgot-password');
-    return;
+    return null;
   }
 
   return (
@@ -81,11 +88,11 @@ const ResetPassword = () => {
               <CardContent className="gap-6">
                 <View className="gap-6">
                   <View className="gap-1.5">
-                    <Label htmlFor="password">Password</Label>
+                    <Label htmlFor="password">New Password</Label>
                     <Input
                       id="password"
                       secureTextEntry
-                      returnKeyType="send"
+                      returnKeyType="next"
                       editable={!isPending}
                       value={form.password}
                       onChangeText={(text) => handleChange('password', text)}
@@ -111,7 +118,7 @@ const ResetPassword = () => {
                     {errors?.otp && <Text className="text-sm text-destructive">{errors?.otp}</Text>}
                   </View>
                   <GoldGradient>
-                    <Button className="bg-transparent w-full" onPress={handleSubmit} disabled={isPending}>
+                    <Button className="bg-transparent w-full font-semibold" onPress={handleSubmit} disabled={isPending}>
                       {isPending ? (
                         <ActivityIndicator color={colorScheme === 'dark' ? '#000000' : '#ffffff'} />
                       ) : (
@@ -125,19 +132,17 @@ const ResetPassword = () => {
           </View>
         </View>
       </ScrollView>
-      <BottomSheet isOpen={isModalOpen}>
-        <View className="bg-green-100 w-16 h-16 rounded-full items-center justify-center self-center mb-4">
-          <IconSymbol name="checkmark.circle" size={24} color="#047857" />
-        </View>
-        <Text className="text-center">Password reset successfully!</Text>
-        <Button className="bg-transparent w-full" onPress={handleCompleteModal}>
-          <Text>Continue</Text>
-          <IconSymbol
-            name="arrow.forward"
-            size={16}
-            className="ml-2"
-            color={colorScheme === 'dark' ? '#000000' : '#ffffff'}
-          />
+      <BottomSheet isOpen={isModalOpen} onClose={handleCompleteModal}>
+        <GoldGradient className="w-16 h-16 rounded-full items-center justify-center self-center mb-8">
+          <IconSymbol name="checkmark.circle" size={40} color={colorScheme === 'dark' ? '#000000' : '#ffffff'} />
+        </GoldGradient>
+        <ThemedText className="text-center text-2xl">Password reset successfully!</ThemedText>
+        <Button
+          className="mt-8 self-center bg-transparent w-full border border-gold items-center"
+          onPress={handleCompleteModal}
+        >
+          <Text className="font-semibold text-gold-text">Continue</Text>
+          <IconSymbol name="arrow.forward" size={16} className="text-gold-text" color={Colors.icon} />
         </Button>
       </BottomSheet>
     </KeyboardAvoidingView>

--- a/mobile/screens/auth/reset-password.tsx
+++ b/mobile/screens/auth/reset-password.tsx
@@ -1,0 +1,137 @@
+import { Button } from '@/components/reusables/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/reusables/ui/card';
+import { Input } from '@/components/reusables/ui/input';
+import { Label } from '@/components/reusables/ui/label';
+import BottomSheet from '@/components/ui/bottom-sheet';
+import GoldGradient from '@/components/ui/gold-gradient';
+import { useLogin, useResetPassword } from '@/features/auth/hook';
+import { resetPasswordSchema, type ResetPasswordSchema } from '@/features/auth/schema';
+import useForm from '@/hooks/use-app-form';
+import { router, useLocalSearchParams } from 'expo-router';
+import React, { useEffect, useRef, useState } from 'react';
+import type { TextInput } from 'react-native';
+import {
+    ActivityIndicator,
+    KeyboardAvoidingView,
+    Platform,
+    ScrollView,
+    Text,
+    useColorScheme,
+    View,
+} from 'react-native';
+
+const ResetPassword = () => {
+  const { mutate: login } = useLogin();
+  const colorScheme = useColorScheme();
+  const [isModalOpen, setModalOpen] = useState(false);
+  const { email } = useLocalSearchParams<{ email?: string }>();
+  const { mutate: resetPassword, isPending, data } = useResetPassword();
+  const { form, errors, handleChange, handleSubmit } = useForm<ResetPasswordSchema>({
+    data: {
+      email: email ?? '',
+      password: '',
+      otp: '',
+    },
+    schema: resetPasswordSchema,
+    onSubmit: (data) => resetPassword(data),
+  });
+
+  const otpRef = useRef<TextInput>(null);
+
+  useEffect(() => {
+    if (data?.success) {
+      setModalOpen(true);
+    }
+  }, [data]);
+
+  const handleCompleteModal = () => {
+    if (!form.email || !form.password) {
+      router.replace('/login');
+      return;
+    }
+    login({ email: form.email, password: form.password });
+  };
+
+  if (!email) {
+    router.replace('/forgot-password');
+    return;
+  }
+
+  return (
+    <KeyboardAvoidingView
+      className="flex-1"
+      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+      keyboardVerticalOffset={Platform.OS === 'ios' ? 80 : 0}
+    >
+      <ScrollView
+        keyboardShouldPersistTaps="handled"
+        contentContainerClassName="sm:flex-1 items-center justify-center p-4 py-8 sm:py-4 sm:p-6 mt-safe"
+        keyboardDismissMode="interactive"
+      >
+        <View className="w-full max-w-sm">
+          <View className="gap-6">
+            <Card className="bg-transparent border-0">
+              <CardHeader>
+                <CardTitle className="text-center text-gold-text text-xl sm:text-left">Reset Your Password</CardTitle>
+                <CardDescription className="text-center sm:text-left">
+                  Enter the One-Time Password sent to your email ({email}) and set your new account password
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="gap-6">
+                <View className="gap-6">
+                  <View className="gap-1.5">
+                    <Label htmlFor="password">Password</Label>
+                    <Input
+                      id="password"
+                      secureTextEntry
+                      returnKeyType="send"
+                      editable={!isPending}
+                      value={form.password}
+                      onChangeText={(text) => handleChange('password', text)}
+                      onSubmitEditing={() => otpRef.current?.focus()}
+                    />
+                    {errors?.password && <Text className="text-sm text-destructive">{errors?.password}</Text>}
+                  </View>
+
+                  <View className="gap-1.5">
+                    <Label htmlFor="otp">OTP Code</Label>
+                    <Input
+                      id="otp"
+                      placeholder="Enter 6-digit code"
+                      keyboardType="number-pad"
+                      editable={!isPending}
+                      value={form.otp}
+                      onChangeText={(text) => handleChange('otp', text)}
+                      returnKeyType="done"
+                      submitBehavior="submit"
+                      maxLength={6}
+                      ref={otpRef}
+                    />
+                    {errors?.otp && <Text className="text-sm text-destructive">{errors?.otp}</Text>}
+                  </View>
+                  <GoldGradient>
+                    <Button className="bg-transparent w-full" onPress={handleSubmit} disabled={isPending}>
+                      {isPending ? (
+                        <ActivityIndicator color={colorScheme === 'dark' ? '#000000' : '#ffffff'} />
+                      ) : (
+                        <Text>Reset Password</Text>
+                      )}
+                    </Button>
+                  </GoldGradient>
+                </View>
+              </CardContent>
+            </Card>
+          </View>
+        </View>
+      </ScrollView>
+      <BottomSheet isOpen={isModalOpen}>
+        <Text>Hello There</Text>
+        <Button className="bg-transparent w-full" onPress={handleCompleteModal}>
+          <Text>Continue</Text>
+        </Button>
+      </BottomSheet>
+    </KeyboardAvoidingView>
+  );
+};
+
+export default ResetPassword;

--- a/mobile/screens/auth/reset-password.tsx
+++ b/mobile/screens/auth/reset-password.tsx
@@ -2,6 +2,7 @@ import { Button } from '@/components/reusables/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/reusables/ui/card';
 import { Input } from '@/components/reusables/ui/input';
 import { Label } from '@/components/reusables/ui/label';
+import { Text } from '@/components/reusables/ui/text';
 import { ThemedText } from '@/components/themed-text';
 import BottomSheet from '@/components/ui/bottom-sheet';
 import GoldGradient from '@/components/ui/gold-gradient';
@@ -13,15 +14,7 @@ import useForm from '@/hooks/use-app-form';
 import { router, useLocalSearchParams } from 'expo-router';
 import React, { useEffect, useRef, useState } from 'react';
 import type { TextInput } from 'react-native';
-import {
-  ActivityIndicator,
-  KeyboardAvoidingView,
-  Platform,
-  ScrollView,
-  Text,
-  useColorScheme,
-  View,
-} from 'react-native';
+import { ActivityIndicator, KeyboardAvoidingView, Platform, ScrollView, useColorScheme, View } from 'react-native';
 
 const ResetPassword = () => {
   const { mutate: login } = useLogin();
@@ -142,7 +135,7 @@ const ResetPassword = () => {
           onPress={handleCompleteModal}
         >
           <Text className="font-semibold text-gold-text">Continue</Text>
-          <IconSymbol name="arrow.forward" size={16} className="text-gold-text" color={Colors.icon} />
+          <IconSymbol name="arrow.forward" size={16} className="text-gold-text" color={Colors.goldIcon} />
         </Button>
       </BottomSheet>
     </KeyboardAvoidingView>

--- a/mobile/screens/auth/verify-email.tsx
+++ b/mobile/screens/auth/verify-email.tsx
@@ -2,19 +2,34 @@ import { Button } from '@/components/reusables/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/reusables/ui/card';
 import { Input } from '@/components/reusables/ui/input';
 import { Text } from '@/components/reusables/ui/text';
+import { ThemedText } from '@/components/themed-text';
+import BottomSheet from '@/components/ui/bottom-sheet';
 import GoldGradient from '@/components/ui/gold-gradient';
-import { useRequestOtp, useVerifyEmail } from '@/features/auth/hook';
+import { IconSymbol } from '@/components/ui/icon-symbol';
+import { Colors } from '@/constants/theme';
+import { useLogin, useRequestOtp, useVerifyEmail } from '@/features/auth/hook';
 import { verifyEmailSchema, type VerifyEmailSchema } from '@/features/auth/schema';
 import { useAuthStore } from '@/features/auth/store';
 import useForm from '@/hooks/use-app-form';
 import { useRouter } from 'expo-router';
 import { useEffect, useState } from 'react';
-import { ActivityIndicator, KeyboardAvoidingView, Platform, Pressable, ScrollView, View } from 'react-native';
+import {
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  ScrollView,
+  View,
+  useColorScheme,
+} from 'react-native';
 
 const VerifyEmail = () => {
+  const colorScheme = useColorScheme();
   const router = useRouter();
+  const { mutate: login } = useLogin();
+  const [isModalOpen, setModalOpen] = useState(false);
   const { credentials } = useAuthStore();
-  const { mutate: verifyEmail, isPending } = useVerifyEmail();
+  const { mutate: verifyEmail, isPending, data: verifyEmailData } = useVerifyEmail();
   const { mutate: requestOtp, isPending: isRequestingOtp, data } = useRequestOtp();
   const [requestOtpCountdown, setRequestOtpCountdown] = useState(60);
   const { form, errors, handleChange, handleSubmit } = useForm<VerifyEmailSchema>({
@@ -45,6 +60,25 @@ const VerifyEmail = () => {
 
     return () => clearTimeout(id);
   }, [isRequestingOtp, requestOtpCountdown]);
+
+  useEffect(() => {
+    if (verifyEmailData?.success) {
+      setModalOpen(true);
+    }
+  }, [verifyEmailData]);
+
+  const handleCompleteModal = () => {
+    if (!credentials?.email || !credentials?.password) {
+      router.replace('/login');
+      return;
+    }
+    login(
+      { email: credentials.email, password: credentials.password },
+      {
+        onError: () => router.replace('/login'),
+      }
+    );
+  };
 
   useEffect(() => {
     if (!credentials?.email) {
@@ -122,6 +156,24 @@ const VerifyEmail = () => {
           </View>
         </View>
       </ScrollView>
+
+      <BottomSheet isOpen={isModalOpen} onClose={handleCompleteModal}>
+        <GoldGradient className="w-16 h-16 rounded-full items-center justify-center self-center mb-8">
+          <IconSymbol
+            name="checkmark.circle"
+            size={40}
+            color={colorScheme === 'dark' ? Colors.dark.background : Colors.light.background}
+          />
+        </GoldGradient>
+        <ThemedText className="text-center text-2xl">Email verified successfully!</ThemedText>
+        <Button
+          className="mt-8 self-center bg-transparent w-full border border-gold items-center"
+          onPress={handleCompleteModal}
+        >
+          <Text className="font-semibold text-gold-text">Continue</Text>
+          <IconSymbol name="arrow.forward" size={16} className="text-gold-text" color={Colors.goldIcon} />
+        </Button>
+      </BottomSheet>
     </KeyboardAvoidingView>
   );
 };

--- a/mobile/screens/auth/verify-email.tsx
+++ b/mobile/screens/auth/verify-email.tsx
@@ -109,7 +109,7 @@ const VerifyEmail = () => {
                   </View>
                   <GoldGradient className="flex-1 self-center">
                     <Button
-                      className="bg-transparent max-w-32"
+                      className="bg-transparent max-w-32 font-semibold"
                       onPress={handleSubmit}
                       disabled={isPending || isRequestingOtp}
                     >


### PR DESCRIPTION
## 📌 Summary

<!-- What does this PR do? Be specific. -->
- adds a Reset Password screen with email, otp and new password set

---

## 🎯 Why is this change needed?

<!-- Link to issue or explain business reason -->
Closes #78

---

## 🧠 What was changed?

<!-- High-level technical explanation -->
- add the screen and a reset confirmation modal.
- 

---

## 🏗️ Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Performance improvement
- [ ] Security fix
- [ ] Documentation update
- [ ] Test improvement
- [ ] Breaking change

---

## 🧪 How was this tested?

<!-- Explain test coverage -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing
- [ ] Postman tested
- [ ] Not tested (explain why)

Test details:
- Screen was tested manually with Expo go

---

## 📸 Screenshots / API Samples (if applicable)

<!-- Example request/response or UI screenshot -->
![Screenshot_20260227_020906_Expo Go.png](https://github.com/user-attachments/assets/d0186e27-c2ab-42ec-926b-a1afc51b6eae)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Reset Password screen and flow with bottom-sheet success confirmation.
  * Introduced a reusable bottom-sheet and a press-scale interaction for tappable controls.
  * Added a confirmation modal after email verification.

* **Usability**
  * Login now auto-focuses the password field after email entry.
  * Forgot Password button label changed to "Request Code".

* **Style**
  * Increased button font weight across auth screens.
  * Added a gold icon color for consistent icon styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->