### PR TITLE
ci: setup GitHub Action for Modal service deployment

### DIFF
--- a/.github/workflows/modal-ci.yml
+++ b/.github/workflows/modal-ci.yml
@@ -28,7 +28,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install Modal
-        run: pip install modal
+        run: pip install modal==1.4.3
 
       - name: Deploy
         env:

--- a/.github/workflows/modal-ci.yml
+++ b/.github/workflows/modal-ci.yml
@@ -1,0 +1,27 @@
+name: Deploy Modal Transcriber
+
+on:
+  push:
+    branches: ["main", "develop"]
+    paths:
+      - 'transcriber/modal-service/transcriber.py'
+      - ".github/workflows/modal-ci.yml"
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Modal
+        run: pip install modal
+
+      - name: Deploy
+        env:
+          MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
+          MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
+        run: modal deploy transcriber.py

--- a/.github/workflows/modal-ci.yml
+++ b/.github/workflows/modal-ci.yml
@@ -10,8 +10,18 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    defaults:
+      run:
+        working-directory: transcriber/modal-service
+
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
## 📌 Summary

- Introduces a new GitHub Actions workflow to automate the deployment of the Modal-based transcription service.
- Enables continuous deployment for the transcription service whenever relevant code or the workflow itself is updated.

---

## 🎯 Why is this change needed?
Closes #182 
- To streamline the deployment process for the transcription service, reducing manual intervention.
- Ensures that updates to the transcription logic in `transcriber/modal-service/transcriber.py` are automatically reflected in the deployed environment.

---

## 🧠 What was changed?

- Added `.github/workflows/modal-ci.yml`:
    - Configured to trigger on `push` to `main` and `develop` branches.
    - Specifically watches paths: `transcriber/modal-service/transcriber.py` and the workflow file itself.
    - Sets up Python 3.11 environment.
    - Installs the `modal` CLI via pip.
    - Executes `modal deploy` using `MODAL_TOKEN_ID` and `MODAL_TOKEN_SECRET` secrets.

---

## 🏗️ Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Performance improvement
- [ ] Security fix
- [ ] Documentation update
- [ ] Test improvement
- [ ] Breaking change

---

## 🧪 How was this tested?

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing
- [ ] Postman tested
- [ ] Not tested (explain why)

Test details:
- The workflow syntax and path triggers were verified against the repository structure.
- *Note: Final verification of the deployment step requires the appropriate secrets to be configured in the GitHub repository.*

---

## 📸 Screenshots / API Samples (if applicable)

N/A (CI/CD Configuration)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated deployment workflow to continuously deploy the transcriber service when relevant changes are pushed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->