### PR TITLE
feat(mobile): implement Library screen & optimize CI/CD and UI components

### DIFF
--- a/.github/workflows/mobile-ci.yml
+++ b/.github/workflows/mobile-ci.yml
@@ -80,9 +80,6 @@ jobs:
       run:
         working-directory: mobile
 
-    env:
-      EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -101,14 +98,14 @@ jobs:
           cache: pnpm
           cache-dependency-path: mobile/pnpm-lock.yaml
 
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
       - name: Setup Expo
         uses: expo/expo-github-action@v8
         with:
           token: ${{ secrets.EXPO_TOKEN }}
           eas-version: 20.4.0
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
 
       - name: Check OTA safety
         run: |
@@ -131,9 +128,6 @@ jobs:
       run:
         working-directory: mobile
 
-    env:
-      EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -152,14 +146,14 @@ jobs:
           cache: pnpm
           cache-dependency-path: mobile/pnpm-lock.yaml
 
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
       - name: Setup Expo
         uses: expo/expo-github-action@v8
         with:
           token: ${{ secrets.EXPO_TOKEN }}
           eas-version: 20.4.0
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
 
       - name: Check OTA safety
         run: |

--- a/mobile/app/(tabs)/library.tsx
+++ b/mobile/app/(tabs)/library.tsx
@@ -1,10 +1,5 @@
-import React from 'react';
-import { Text, View } from 'react-native';
+import LibraryScreen from '@/screens/library';
 
 export default function LibraryRoute() {
-  return (
-    <View>
-      <Text>LibraryRoute</Text>
-    </View>
-  );
+  return <LibraryScreen />
 }

--- a/mobile/components/core/icon.ios.tsx
+++ b/mobile/components/core/icon.ios.tsx
@@ -32,6 +32,11 @@ const MAPPING: Record<IconSymbolName, SymbolViewProps['name']> = {
   'check.circle.outline': 'checkmark.circle',
   flame: 'flame',
   'menu.horizontal': 'ellipsis',
+  'calendar.outline': 'calendar',
+  series: 'list.bullet.rectangle',
+  folder: 'folder',
+  'bookmark.outline': 'bookmark',
+  'download.outline': 'arrow.down.circle',
 };
 
 export function Icon({

--- a/mobile/components/core/icon.tsx
+++ b/mobile/components/core/icon.tsx
@@ -1,15 +1,14 @@
 import { useAppTheme } from '@/hooks/use-app-theme';
-import { FontAwesome, Ionicons, MaterialIcons } from '@expo/vector-icons';
+import { Ionicons, MaterialIcons } from '@expo/vector-icons';
 import type { SymbolWeight } from 'expo-symbols';
 import type { ComponentProps } from 'react';
 import type { OpaqueColorValue, StyleProp, TextStyle } from 'react-native';
 
-type IconFamily = 'MaterialIcons' | 'Ionicons' | 'FontAwesome';
+type IconFamily = 'MaterialIcons' | 'Ionicons'; 
 
 type IconFamilyMap = {
   MaterialIcons: typeof MaterialIcons;
   Ionicons: typeof Ionicons;
-  FontAwesome: typeof FontAwesome;
 };
 
 type IconMappingEntry = {
@@ -26,8 +25,8 @@ const MAPPING = {
   'home.outline': { name: 'home-outline', family: 'Ionicons' },
   search: { name: 'search-sharp', family: 'Ionicons' },
   'search.outline': { name: 'search-outline', family: 'Ionicons' },
-  library: { name: 'book', family: 'FontAwesome' },
-  'library.outline': { name: 'book', family: 'FontAwesome' },
+  library: { name: 'library', family: 'Ionicons' },
+  'library.outline': { name: 'library-outline', family: 'Ionicons' },
   activity: { name: 'trending-up', family: 'MaterialIcons' },
   'activity.outline': { name: 'trending-up', family: 'MaterialIcons' },
   profile: { name: 'person', family: 'Ionicons' },
@@ -47,6 +46,11 @@ const MAPPING = {
   'check.circle.outline': { name: 'check-circle-outline', family: 'MaterialIcons' },
   flame: { name: 'flame', family: 'Ionicons' },
   'menu.horizontal': { name: 'ellipsis-horizontal', family: 'Ionicons' },
+  'calendar.outline': { name: 'calendar-outline', family: 'Ionicons' },
+  series: { name: 'playlist-play', family: 'MaterialIcons' },
+  folder: { name: 'folder-open-outline', family: 'Ionicons' },
+  'bookmark.outline': { name: 'bookmark-outline', family: 'Ionicons' },
+  'download.outline': { name: 'download-outline', family: 'Ionicons' },
 } satisfies IconMapping;
 
 export type IconSymbolName = keyof typeof MAPPING;
@@ -81,8 +85,6 @@ export function Icon({
   switch (MAPPING[name]['family']) {
     case 'Ionicons':
       return <Ionicons color={color} size={size} name={MAPPING[name].name} style={style} className={className} />;
-    case 'FontAwesome':
-      return <FontAwesome color={color} size={size} name={MAPPING[name].name} style={style} className={className} />;
     case 'MaterialIcons':
     default:
       return <MaterialIcons color={color} size={size} name={MAPPING[name].name} style={style} className={className} />;

--- a/mobile/components/ui/opacity-pressable.tsx
+++ b/mobile/components/ui/opacity-pressable.tsx
@@ -1,6 +1,8 @@
 import React, { useRef } from 'react';
 import { Animated, Pressable, type PressableProps, type StyleProp, type ViewStyle } from 'react-native';
 
+const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
+
 interface OpacityPressableProps extends PressableProps {
   children: React.ReactNode;
   style?: StyleProp<ViewStyle>;
@@ -64,7 +66,9 @@ export default function OpacityPressable({
   };
 
   return (
-    <Pressable
+    <AnimatedPressable
+      className={className}
+      style={[style, { transform: [{ scale }], opacity }]}
       onPressIn={(e) => {
         animateIn();
         onPressIn?.(e);
@@ -75,9 +79,7 @@ export default function OpacityPressable({
       }}
       {...rest}
     >
-      <Animated.View className={className} style={[style, { transform: [{ scale }], opacity }]}>
-        {children}
-      </Animated.View>
-    </Pressable>
+      {children}
+    </AnimatedPressable>
   );
 }

--- a/mobile/screens/home/components/stats-card.tsx
+++ b/mobile/screens/home/components/stats-card.tsx
@@ -16,7 +16,7 @@ export default function StatsCard({ icon, title, subtitle, tagColor, iconColor }
 
   return (
     <View
-      className="flex-1 justify-center items-center w-max rounded-xl border"
+      className="flex-1 justify-center items-center rounded-xl border"
       style={{
         backgroundColor: color.cardBackground,
         borderColor: color.cardBorder,

--- a/mobile/screens/library/components/library-card.tsx
+++ b/mobile/screens/library/components/library-card.tsx
@@ -1,0 +1,36 @@
+import { View, Text, Icon, type IconSymbolName } from '@/components/core';
+import OpacityPressable from '@/components/ui/opacity-pressable';
+import { FontFamily, FontSize } from '@/constants';
+import { hexToRgba } from '@/lib/utils';
+
+interface LibraryCardProps {
+  icon: IconSymbolName;
+  title: string;
+  label: string;
+  color: string;
+}
+
+export default function LibraryCard({ icon, label, title, color }: LibraryCardProps) {
+
+  return (
+    <OpacityPressable
+      onPress={() => {}}
+      activeOpacity={0.4}
+      className="flex-1 justify-center rounded-xl border p-4"
+      style={{
+        backgroundColor: hexToRgba(color, 0.15),
+        borderColor: hexToRgba(color, 0.3),
+      }}
+    >
+      <View className="self-start mb-3 p-2 rounded-md" style={{ backgroundColor: color }}>
+        <Icon name={icon} size={FontSize.lg} color={'#FFFFFF'} />
+      </View>
+      <Text size={FontSize.md} style={{ fontFamily: FontFamily.Outfit_500Medium }}>
+        {title}
+      </Text>
+      <Text variant="label" size={FontSize.xs}>
+        {label}
+      </Text>
+    </OpacityPressable>
+  )
+}

--- a/mobile/screens/library/components/library-card.tsx
+++ b/mobile/screens/library/components/library-card.tsx
@@ -2,19 +2,22 @@ import { View, Text, Icon, type IconSymbolName } from '@/components/core';
 import OpacityPressable from '@/components/ui/opacity-pressable';
 import { FontFamily, FontSize } from '@/constants';
 import { hexToRgba } from '@/lib/utils';
+import { useRouter, type Href } from 'expo-router';
 
 interface LibraryCardProps {
   icon: IconSymbolName;
   title: string;
   label: string;
   color: string;
+  link: Href;
 }
 
-export default function LibraryCard({ icon, label, title, color }: LibraryCardProps) {
+export default function LibraryCard({ icon, label, title, color, link }: LibraryCardProps) {
+  const router = useRouter();
 
   return (
     <OpacityPressable
-      onPress={() => {}}
+      onPress={() => router.push(link)}
       activeOpacity={0.4}
       className="flex-1 justify-center rounded-xl border p-4"
       style={{
@@ -32,5 +35,5 @@ export default function LibraryCard({ icon, label, title, color }: LibraryCardPr
         {label}
       </Text>
     </OpacityPressable>
-  )
+  );
 }

--- a/mobile/screens/library/components/recently-updated-card.tsx
+++ b/mobile/screens/library/components/recently-updated-card.tsx
@@ -1,0 +1,50 @@
+import { Image, type ImageSourcePropType, Text, View } from '@/components/core';
+import ScalePressable from '@/components/ui/scale-pressable';
+import Tag from '@/components/ui/tag';
+import { Colors, FontFamily, FontSize } from '@/constants';
+import { useAppTheme } from '@/hooks/use-app-theme';
+import { useRouter } from 'expo-router';
+import { differenceInCalendarDays } from 'date-fns';
+
+interface RecentlyUpdatedCardProps {
+  id: number;
+  thumbnailUrl: ImageSourcePropType;
+  title: string;
+  createdAt: Date;
+  tagColor: string;
+  type: 'SERIES' | 'COLLECTION';
+}
+
+export default function RecentlyUpdatedCard({ id, thumbnailUrl, title, createdAt, tagColor, type }: RecentlyUpdatedCardProps) {
+  const router = useRouter();
+  const { color } = useAppTheme();
+
+  return (
+    <ScalePressable onPress={() => router.push('/(tabs)/home')} className="w-40 mr-3">
+      <View
+        className="relative mr-2 border rounded-xl"
+        style={{ backgroundColor: color.cardBackground, borderColor: color.cardBorder }}
+      >
+        <Image source={thumbnailUrl} className="object-cover w-40 h-32 rounded-xl" />
+        <View className="absolute top-0 right-0 py-1 rounded-b-xl">
+          <Tag color={tagColor} backgroundColor={tagColor} textColor={Colors.dark.text} text={type} className='capitalize' />
+        </View>
+      </View>
+
+      <View className="py-3 px-1">
+        <Text
+          variant="title"
+          size={FontSize.base - 1}
+          numberOfLines={2}
+          className="font-semibold text-wrap"
+          style={{ fontFamily: FontFamily.Outfit_500Medium }}
+        >
+          {title}
+        </Text>
+        <Text variant="label" size={FontSize.xs} className="mt-auto">
+          Updated {differenceInCalendarDays(new Date(), createdAt)} days ago
+        </Text>
+      </View>
+    </ScalePressable>
+  );
+}

--- a/mobile/screens/library/components/recently-updated-card.tsx
+++ b/mobile/screens/library/components/recently-updated-card.tsx
@@ -19,15 +19,18 @@ export default function RecentlyUpdatedCard({ id, thumbnailUrl, title, createdAt
   const router = useRouter();
   const { color } = useAppTheme();
 
+  const daysAgo = differenceInCalendarDays(new Date(), createdAt);
+  const relativeTime = daysAgo <= 0 ? 'today' : daysAgo === 1 ? 'yesterday' : `${daysAgo} days ago`;
+
   return (
-    <ScalePressable onPress={() => router.push('/(tabs)/home')} className="w-40 mr-3">
+    <ScalePressable onPress={() => router.push('/(tabs)/library')} className="w-40 mr-3">
       <View
-        className="relative mr-2 border rounded-xl"
+        className="relative border rounded-xl"
         style={{ backgroundColor: color.cardBackground, borderColor: color.cardBorder }}
       >
         <Image source={thumbnailUrl} className="object-cover w-40 h-32 rounded-xl" />
         <View className="absolute top-0 right-0 py-1 rounded-b-xl">
-          <Tag color={tagColor} backgroundColor={tagColor} textColor={Colors.dark.text} text={type} className='capitalize' />
+          <Tag color={tagColor} backgroundColor={tagColor} textColor={Colors.dark.text} text={type} className="capitalize" />
         </View>
       </View>
 
@@ -42,7 +45,7 @@ export default function RecentlyUpdatedCard({ id, thumbnailUrl, title, createdAt
           {title}
         </Text>
         <Text variant="label" size={FontSize.xs} className="mt-auto">
-          Updated {differenceInCalendarDays(new Date(), createdAt)} days ago
+          Updated {relativeTime}
         </Text>
       </View>
     </ScalePressable>

--- a/mobile/screens/library/index.tsx
+++ b/mobile/screens/library/index.tsx
@@ -4,39 +4,38 @@ import LibraryCard from './components/library-card';
 import { FlatList } from 'react-native';
 import RecentlyUpdatedCard from './components/recently-updated-card';
 
+const recentlyUpdateds = [
+  {
+    id: 1,
+    title: 'Commanding The Supernatural',
+    thumbnailUrl: require('@/assets/images/p1.jpg'),
+    createdAt: new Date('2026-07-01'),
+    type: 'SERIES' as const,
+  },
+  {
+    id: 2,
+    title: 'Complete Deliverance',
+    thumbnailUrl: require('@/assets/images/p2.jpg'),
+    createdAt: new Date('2026-06-30'),
+    type: 'COLLECTION' as const,
+  },
+  {
+    id: 3,
+    title: 'Striving for Mastery',
+    thumbnailUrl: require('@/assets/images/p3.jpg'),
+    createdAt: new Date('2026-07-05'),
+    type: 'SERIES' as const,
+  },
+  {
+    id: 4,
+    title: 'Weapons of Warfare: Destroying the stronghold of the Wicked',
+    thumbnailUrl: require('@/assets/images/p4.jpg'),
+    createdAt: new Date('2026-06-10'),
+    type: 'COLLECTION' as const,
+  },
+];
+
 export default function LibraryScreen() {
-
-  const recentlyUpdateds = [
-    {
-      id: 1,
-      title: 'Commanding The Supernatural',
-      thumbnailUrl: require('@/assets/images/p1.jpg'),
-      createdAt: new Date('2026-07-01'),
-      type: 'SERIES' as 'SERIES' | 'COLLECTION'
-    },
-    {
-      id: 2,
-      title: 'Complete Deliverance',
-      thumbnailUrl: require('@/assets/images/p2.jpg'),
-      createdAt: new Date('2026-06-30'),
-      type: 'COLLECTION' as 'SERIES' | 'COLLECTION'
-    },
-    {
-      id: 3,
-      title: 'Striving for Mastery',
-      thumbnailUrl: require('@/assets/images/p3.jpg'),
-      createdAt: new Date('2026-07-05'),
-      type: 'SERIES' as 'SERIES' | 'COLLECTION'
-    },
-    {
-      id: 4,
-      title: 'Weapons of Warfare: Destroying the stronghold of the Wicked',
-      thumbnailUrl: require('@/assets/images/p4.jpg'),
-      createdAt: new Date('2026-06-10'),
-      type: 'COLLECTION' as 'SERIES' | 'COLLECTION'
-    },
-  ];
-
   return (
     <Screen scrollable edges={['top']} contentContainerClassName="px-4 pt-2">
       <View className="my-4">
@@ -51,13 +50,25 @@ export default function LibraryScreen() {
         </Text>
 
         <View className="flex-row gap-3 w-full my-2">
-          <LibraryCard icon='library.outline' title='All Teachings' label='Browse everything, filter by type' color={'#3B82F6'} />
-          <LibraryCard icon='calendar.outline' title='Sunday Services' label='Browse chronologically by year' color={'#22C55E'} />
+          <LibraryCard
+            icon="library.outline"
+            title="All Teachings"
+            label="Browse everything, filter by type"
+            color={'#3B82F6'}
+            link={'/library'}
+          />
+          <LibraryCard
+            icon="calendar.outline"
+            title="Sunday Services"
+            label="Browse chronologically by year"
+            color={'#22C55E'}
+            link={'/library'}
+          />
         </View>
 
         <View className="flex-row gap-3 w-full my-2">
-          <LibraryCard icon='series' title='Series' label='Sequential teaching journeys' color={'#8B5CF6'} />
-          <LibraryCard icon='folder' title='Collections' label='Curated related teachings' color={'#F59E0B'} />
+          <LibraryCard icon="series" title="Series" label="Sequential teaching journeys" color={'#8B5CF6'} link={'/library'} />
+          <LibraryCard icon="folder" title="Collections" label="Curated related teachings" color={'#F59E0B'} link={'/library'} />
         </View>
       </View>
 
@@ -67,8 +78,14 @@ export default function LibraryScreen() {
         </Text>
 
         <View className="flex-row gap-3 w-full my-2">
-          <LibraryCard icon='bookmark.outline' title='My Bookmarks' label='4 collections • 30 saved' color={'#EC4899'} />
-          <LibraryCard icon='download.outline' title='My Downloads' label='6 teachings' color={'#06B6D4'} />
+          <LibraryCard
+            icon="bookmark.outline"
+            title="My Bookmarks"
+            label="4 collections • 30 saved"
+            color={'#EC4899'}
+            link={'/library'}
+          />
+          <LibraryCard icon="download.outline" title="My Downloads" label="6 teachings" color={'#06B6D4'} link={'/library'} />
         </View>
       </View>
 
@@ -82,7 +99,7 @@ export default function LibraryScreen() {
           keyExtractor={(item) => item.id.toString()}
           horizontal={true}
           showsHorizontalScrollIndicator={false}
-          contentContainerClassName='my-2'
+          contentContainerClassName="my-2"
           renderItem={({ item }) => (
             <RecentlyUpdatedCard
               id={item.id}

--- a/mobile/screens/library/index.tsx
+++ b/mobile/screens/library/index.tsx
@@ -1,0 +1,100 @@
+import { Screen, View, Text } from '@/components/core';
+import { FontFamily, FontSize } from '@/constants';
+import LibraryCard from './components/library-card';
+import { FlatList } from 'react-native';
+import RecentlyUpdatedCard from './components/recently-updated-card';
+
+export default function LibraryScreen() {
+
+  const recentlyUpdateds = [
+    {
+      id: 1,
+      title: 'Commanding The Supernatural',
+      thumbnailUrl: require('@/assets/images/p1.jpg'),
+      createdAt: new Date('2026-07-01'),
+      type: 'SERIES' as 'SERIES' | 'COLLECTION'
+    },
+    {
+      id: 2,
+      title: 'Complete Deliverance',
+      thumbnailUrl: require('@/assets/images/p2.jpg'),
+      createdAt: new Date('2026-06-30'),
+      type: 'COLLECTION' as 'SERIES' | 'COLLECTION'
+    },
+    {
+      id: 3,
+      title: 'Striving for Mastery',
+      thumbnailUrl: require('@/assets/images/p3.jpg'),
+      createdAt: new Date('2026-07-05'),
+      type: 'SERIES' as 'SERIES' | 'COLLECTION'
+    },
+    {
+      id: 4,
+      title: 'Weapons of Warfare: Destroying the stronghold of the Wicked',
+      thumbnailUrl: require('@/assets/images/p4.jpg'),
+      createdAt: new Date('2026-06-10'),
+      type: 'COLLECTION' as 'SERIES' | 'COLLECTION'
+    },
+  ];
+
+  return (
+    <Screen scrollable edges={['top']} contentContainerClassName="px-4 pt-2">
+      <View className="my-4">
+        <Text variant="title" size={FontSize.xl + 4} family={FontFamily.Lora_500Medium} style={{ fontWeight: 'bold' }}>
+          Library
+        </Text>
+      </View>
+
+      <View className="my-2">
+        <Text variant="title" size={FontSize.lg} family={FontFamily.Lora_500Medium} style={{ fontWeight: 'bold' }}>
+          Browse
+        </Text>
+
+        <View className="flex-row gap-3 w-full my-2">
+          <LibraryCard icon='library.outline' title='All Teachings' label='Browse everything, filter by type' color={'#3B82F6'} />
+          <LibraryCard icon='calendar.outline' title='Sunday Services' label='Browse chronologically by year' color={'#22C55E'} />
+        </View>
+
+        <View className="flex-row gap-3 w-full my-2">
+          <LibraryCard icon='series' title='Series' label='Sequential teaching journeys' color={'#8B5CF6'} />
+          <LibraryCard icon='folder' title='Collections' label='Curated related teachings' color={'#F59E0B'} />
+        </View>
+      </View>
+
+      <View className="my-2">
+        <Text variant="title" size={FontSize.lg} family={FontFamily.Lora_500Medium} style={{ fontWeight: 'bold' }}>
+          My Library
+        </Text>
+
+        <View className="flex-row gap-3 w-full my-2">
+          <LibraryCard icon='bookmark.outline' title='My Bookmarks' label='4 collections • 30 saved' color={'#EC4899'} />
+          <LibraryCard icon='download.outline' title='My Downloads' label='6 teachings' color={'#06B6D4'} />
+        </View>
+      </View>
+
+      <View className="mt-4">
+        <Text variant="title" size={FontSize.lg} family={FontFamily.Lora_500Medium} style={{ fontWeight: 'bold' }}>
+          Recently Updated
+        </Text>
+
+        <FlatList
+          data={recentlyUpdateds}
+          keyExtractor={(item) => item.id.toString()}
+          horizontal={true}
+          showsHorizontalScrollIndicator={false}
+          contentContainerClassName='my-2'
+          renderItem={({ item }) => (
+            <RecentlyUpdatedCard
+              id={item.id}
+              thumbnailUrl={item.thumbnailUrl}
+              title={item.title}
+              createdAt={item.createdAt}
+              tagColor={item.type === 'SERIES' ? '#8B5CF6' : '#F59E0B'}
+              type={item.type}
+            />
+          )}
+        />
+      </View>
+    </Screen>
+  );
+}


### PR DESCRIPTION

## 📌 Summary

This PR implements the dedicated Library screen features, integrates it into the tab navigation, resolves platform-specific icon mappings, refactors the `OpacityPressable` component for efficiency, and corrects CI/CD build issues.

---

## 🎯 Why is this change needed?
Closes #206 
Users need a central dashboard to browse teachings (all teachings, Sunday services, series, collections) and access user-specific content (bookmarks and downloaded sermons) along with recently updated items. Additionally, CI/CD optimizations ensure dependencies are cleanly resolved before configuring the Expo CLI environment.

---

## 🧠 What was changed?

- **Library Screen View:**
  - Created a new Library screen page at `mobile/screens/library/index.tsx` consisting of browse categories (Sunday services, Series, Collections, All Teachings) and personal folders (Bookmarks, Downloads).
  - Created `LibraryCard` and `RecentlyUpdatedCard` components to render list items.
  - Linked the main library router tab `mobile/app/(tabs)/library.tsx` to mount the new library screen.
  
- **Icon Library Migration:**
  - Migrated `library` and `library.outline` icons from `FontAwesome` to `Ionicons`.
  - Added new mappings for `calendar.outline`, `series`, `folder`, `bookmark.outline`, and `download.outline` icons across both cross-platform `mobile/components/core/icon.tsx` and platform-specific `mobile/components/core/icon.ios.tsx`.

- **UI Component Refactoring:**
  - Simplified `OpacityPressable` (`mobile/components/ui/opacity-pressable.tsx`) by converting the base wrapper into an `AnimatedPressable` instead of using a separate nested `Animated.View`.
  - Removed unsupported `w-max` Tailwind class from the home `StatsCard` wrapper in `mobile/screens/home/components/stats-card.tsx` to fix layout quirks.

- **GitHub Actions Adjustments:**
  - Updated `.github/workflows/mobile-ci.yml` to run dependencies installation (`pnpm install --frozen-lockfile`) before setting up Expo, ensuring command-line dependencies are ready. Removed redundant job-level `EXPO_TOKEN` environment variables.

---

## 🏗️ Type of Change

- [x] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Performance improvement
- [ ] Security fix
- [ ] Documentation update
- [ ] Test improvement
- [ ] Breaking change

---

## 🧪 How was this tested?

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing
- [ ] Postman tested
- [ ] Not tested (explain why)

Test details:
- Manually verified the layout, list scrolling, navigation, and responsiveness of the newly integrated Library screen in the mobile app environment.
- Checked iOS icon rendering mappings.

---

## 📸 Screenshots / API Samples (if applicable)

<!-- Example UI screenshot placeholder -->
Library Screen Home and Recently Updated Card

![Screenshot_20260708_192735_Expo Go.png](https://github.com/user-attachments/assets/4c7feda1-ef96-4394-8b1c-07d3fc73fb76)

![Screenshot_20260708_192748_Expo Go.png](https://github.com/user-attachments/assets/dcf1a15f-bb52-428b-a3ee-35a903c6998b)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Library screen with browse options, personal library shortcuts, and a “Recently Updated” section.
  * Introduced tappable library cards that take you directly to the selected content.
  * Expanded icon support for additional symbols used across the app.

* **Bug Fixes**
  * Improved press animations for smoother, more consistent touch feedback.
  * Updated layout behavior in a stats card to better fit available space.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->